### PR TITLE
Backend jwt blacklist

### DIFF
--- a/backend/TraderX/pom.xml
+++ b/backend/TraderX/pom.xml
@@ -25,6 +25,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>com.hazelcast</groupId>
+			<artifactId>hazelcast</artifactId>
+			<version>3.12.2</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mail</artifactId>
 			<version>2.0.1.RELEASE</version>

--- a/backend/TraderX/src/main/java/cmpe451/group6/Group6BackendService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/Group6BackendService.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 import cmpe451.group6.authorization.model.RegistrationStatus;
+import cmpe451.group6.authorization.service.HazelcastService;
 import cmpe451.group6.authorization.service.SignupService;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +16,6 @@ import org.springframework.context.annotation.Bean;
 import cmpe451.group6.authorization.model.Role;
 import cmpe451.group6.authorization.model.User;
 
-// TODO: Garbage collection for multiple tokens for the same user
 // TODO: Interface for user to supply new password when resent link is sent. (Frontend related.)
 // TODO: Store hardcoded values in application.properties or some config class.
 
@@ -34,7 +34,6 @@ public class Group6BackendService implements CommandLineRunner {
     return new ModelMapper();
   }
 
-
   // Predefined admin user with full privileges
   @Override
   public void run(String... params) throws Exception {
@@ -47,7 +46,10 @@ public class Group6BackendService implements CommandLineRunner {
     admin.setStatus(RegistrationStatus.ENABLED);
     admin.setRoles(new ArrayList<Role>(Arrays.asList(Role.ROLE_ADMIN)));
 
-    signupService.admin_signup(admin);
+    String token = signupService.admin_signup(admin);
+
+    HazelcastService.invalidateToken(token,"admin");
+
   }
 
 }

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/controller/UserController.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/controller/UserController.java
@@ -70,7 +70,7 @@ public class UserController {
   @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_BASIC') or hasRole('ROLE_TRADER')")
   @ApiOperation(value = "Returns a new token for the user.", response = String.class)
   public TokenWrapperDTO refresh(HttpServletRequest req) {
-    return userService.refreshToken(req.getRemoteUser());
+    return userService.refreshToken(req.getRemoteUser(),req);
   }
 
 

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/security/JwtTokenFilter.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/security/JwtTokenFilter.java
@@ -55,8 +55,8 @@ public class JwtTokenFilter extends OncePerRequestFilter {
       if (token != null && jwtTokenProvider.validateToken(token)) {
 
         // If token is in blacklist, return error response
-        if(HazelcastService.isInBlacklist(token)){
-          httpServletResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token is in blacklist.");
+        if(HazelcastService.isBlackToken(token)){
+          httpServletResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token has been invalidated.");
           return;
         }
 

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/security/JwtTokenFilter.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/security/JwtTokenFilter.java
@@ -12,6 +12,7 @@ import cmpe451.group6.authorization.exception.CustomException;
 import cmpe451.group6.authorization.model.RegistrationStatus;
 import cmpe451.group6.authorization.model.User;
 import cmpe451.group6.authorization.repository.UserRepository;
+import cmpe451.group6.authorization.service.HazelcastService;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -52,6 +53,12 @@ public class JwtTokenFilter extends OncePerRequestFilter {
     try {
 
       if (token != null && jwtTokenProvider.validateToken(token)) {
+
+        // If token is in blacklist, return error response
+        if(HazelcastService.isInBlacklist(token)){
+          httpServletResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Token is in blacklist.");
+          return;
+        }
 
         Authentication auth = jwtTokenProvider.getAuthentication(token);
 

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/security/JwtTokenProvider.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/security/JwtTokenProvider.java
@@ -50,8 +50,9 @@ public class JwtTokenProvider {
 
   public String createToken(String username, List<Role> roles) {
 
-    if(HazelcastService.isWhiteToken(username)){
-      throw new CustomException("Already have an active token.", HttpStatus.CONFLICT);
+    if(HazelcastService.whiteTokensCount(username) > 10){
+      throw new CustomException("More than 10 active tokens exist for that user. The account is banned from" +
+              "the system for 30 minutes.", HttpStatus.TOO_MANY_REQUESTS);
     }
 
     Claims claims = Jwts.claims().setSubject(username);

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/security/JwtTokenProvider.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/security/JwtTokenProvider.java
@@ -11,7 +11,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import cmpe451.group6.authorization.exception.CustomException;
 import cmpe451.group6.authorization.model.Role;
-import cmpe451.group6.authorization.repository.UserRepository;
+import cmpe451.group6.authorization.service.HazelcastService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -50,18 +50,25 @@ public class JwtTokenProvider {
 
   public String createToken(String username, List<Role> roles) {
 
+    if(HazelcastService.isWhiteToken(username)){
+      throw new CustomException("Already have an active token.", HttpStatus.CONFLICT);
+    }
+
     Claims claims = Jwts.claims().setSubject(username);
     claims.put("auth", roles.stream().map(s -> new SimpleGrantedAuthority(s.getAuthority())).filter(Objects::nonNull).collect(Collectors.toList()));
 
     Date now = new Date();
     Date validity = new Date(now.getTime() + validityInMilliseconds);
 
-    return Jwts.builder()//
+    String token =  Jwts.builder()//
         .setClaims(claims)//
         .setIssuedAt(now)//
         .setExpiration(validity)//
         .signWith(SignatureAlgorithm.HS256, secretKey)//
         .compact();
+
+    HazelcastService.putWhiteToken(token, username);
+    return token;
   }
 
   public Authentication getAuthentication(String token) {

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/HazelcastService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/HazelcastService.java
@@ -4,6 +4,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.query.Predicate;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -54,6 +55,10 @@ public class HazelcastService {
 
     public static boolean isBlackToken(String token){
         return getBlacklistMap().get(token) != null;
+    }
+
+    public static int whiteTokensCount(String username){
+         return getWhitelistMap().values((Predicate) entry -> entry.getValue().equals(username)).size();
     }
 
 }

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/HazelcastService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/HazelcastService.java
@@ -1,0 +1,37 @@
+package cmpe451.group6.authorization.service;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HazelcastService {
+
+    //@Value("${security.jwt.token.expire-length}")
+    private final static int TOKEN_EXPIRATION_TIME_MS = 1800000;
+
+    private static final String HAZELCAST_BLACKLIST_MAP_NAME = "blacklist_map";
+
+    private static HazelcastInstance hazelcastInstance = initHazelcast();
+
+    private static HazelcastInstance initHazelcast(){
+        Config config = new Config();
+        config.getGroupConfig().setName("BLACKLIST_CLUSTER");
+        config.getMapConfig(HAZELCAST_BLACKLIST_MAP_NAME).setTimeToLiveSeconds(TOKEN_EXPIRATION_TIME_MS);
+        return Hazelcast.newHazelcastInstance(config);
+    }
+
+    private static IMap<String,String> getBlacklistMap() {
+        return hazelcastInstance.getMap(HAZELCAST_BLACKLIST_MAP_NAME);
+    }
+
+    public static void putBlacklist(String token, String username){
+        getBlacklistMap().put(token, username);
+    }
+
+    public static boolean isInBlacklist(String token){
+        return getBlacklistMap().get(token) != null;
+    }
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/PasswordService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/PasswordService.java
@@ -1,5 +1,6 @@
 package cmpe451.group6.authorization.service;
 
+import cmpe451.group6.Group6BackendService;
 import cmpe451.group6.authorization.email.EmailService;
 import cmpe451.group6.authorization.exception.CustomException;
 import cmpe451.group6.authorization.model.User;
@@ -40,6 +41,9 @@ public class PasswordService {
                 e.printStackTrace();
                 throw new CustomException(String.format("Failed to send verification email to the address: %s", mail) , HttpStatus.INTERNAL_SERVER_ERROR);
             }
+            // Invalidate token;
+            HazelcastService.putBlacklist(token, user.getUsername());
+
             return "Link to reset password has been sent to your email.";
         } else {
             throw new CustomException("No user found for the email", HttpStatus.BAD_REQUEST);
@@ -53,6 +57,8 @@ public class PasswordService {
             User user = userRepository.findByUsername(username);
             user.setPassword(passwordEncoder.encode(newPassword));
             userRepository.save(user);
+            // Invalidate token;
+            HazelcastService.putBlacklist(token, user.getUsername());
             return "Password has been changed.";
         } catch (AuthenticationException e) {
             throw new CustomException("Invalid TOKEN", HttpStatus.UNAUTHORIZED);

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/PasswordService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/PasswordService.java
@@ -1,6 +1,5 @@
 package cmpe451.group6.authorization.service;
 
-import cmpe451.group6.Group6BackendService;
 import cmpe451.group6.authorization.email.EmailService;
 import cmpe451.group6.authorization.exception.CustomException;
 import cmpe451.group6.authorization.model.User;
@@ -8,7 +7,6 @@ import cmpe451.group6.authorization.repository.UserRepository;
 import cmpe451.group6.authorization.security.JwtTokenProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -56,7 +54,7 @@ public class PasswordService {
             user.setPassword(passwordEncoder.encode(newPassword));
             userRepository.save(user);
             // Invalidate token;
-            HazelcastService.putBlacklist(token, user.getUsername());
+            HazelcastService.invalidateToken(token, user.getUsername());
             return "Password has been changed.";
         } catch (AuthenticationException e) {
             throw new CustomException("Invalid TOKEN", HttpStatus.UNAUTHORIZED);

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/PasswordService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/PasswordService.java
@@ -41,8 +41,6 @@ public class PasswordService {
                 e.printStackTrace();
                 throw new CustomException(String.format("Failed to send verification email to the address: %s", mail) , HttpStatus.INTERNAL_SERVER_ERROR);
             }
-            // Invalidate token;
-            HazelcastService.putBlacklist(token, user.getUsername());
 
             return "Link to reset password has been sent to your email.";
         } else {

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/UserService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/UserService.java
@@ -3,6 +3,7 @@ package cmpe451.group6.authorization.service;
 import javax.mail.MessagingException;
 import javax.servlet.http.HttpServletRequest;
 
+import cmpe451.group6.Group6BackendService;
 import cmpe451.group6.authorization.dto.TokenWrapperDTO;
 import cmpe451.group6.authorization.email.EmailService;
 import cmpe451.group6.authorization.model.RegistrationStatus;
@@ -53,7 +54,9 @@ public class UserService {
     return userRepository.findByUsername(jwtTokenProvider.getUsername(jwtTokenProvider.resolveToken(req)));
   }
 
-  public TokenWrapperDTO refreshToken(String username) {
+  public TokenWrapperDTO refreshToken(String username, HttpServletRequest req) {
+    String currentToken = jwtTokenProvider.resolveToken(req);
+    HazelcastService.putBlacklist(currentToken, username);
     return new TokenWrapperDTO(jwtTokenProvider.createToken(username, userRepository.findByUsername(username).getRoles()));
   }
 

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/UserService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/UserService.java
@@ -1,29 +1,16 @@
 package cmpe451.group6.authorization.service;
 
-import javax.mail.MessagingException;
 import javax.servlet.http.HttpServletRequest;
 
-import cmpe451.group6.Group6BackendService;
 import cmpe451.group6.authorization.dto.TokenWrapperDTO;
-import cmpe451.group6.authorization.email.EmailService;
-import cmpe451.group6.authorization.model.RegistrationStatus;
-import cmpe451.group6.authorization.model.Role;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import cmpe451.group6.authorization.exception.CustomException;
 import cmpe451.group6.authorization.model.User;
 import cmpe451.group6.authorization.repository.UserRepository;
 import cmpe451.group6.authorization.security.JwtTokenProvider;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 
 @Service
 public class UserService {
@@ -56,7 +43,7 @@ public class UserService {
 
   public TokenWrapperDTO refreshToken(String username, HttpServletRequest req) {
     String currentToken = jwtTokenProvider.resolveToken(req);
-    HazelcastService.putBlacklist(currentToken, username);
+    HazelcastService.invalidateToken(currentToken, username);
     return new TokenWrapperDTO(jwtTokenProvider.createToken(username, userRepository.findByUsername(username).getRoles()));
   }
 


### PR DESCRIPTION
Invalidated JWTs are added a blacklist maintained by Hazelcast. 

- When a new password is set or a reset link is sent using a token, then the token is invalidated.
- Also, if a client asks to refresh a token, the older one is invalidated.

In JwtFilter, a token is checked if it's in the blacklist and if so returns error.