### PR TITLE
Backend profile

### DIFF
--- a/backend/TraderX/src/main/java/cmpe451/group6/Group6BackendService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/Group6BackendService.java
@@ -52,7 +52,7 @@ public class Group6BackendService implements CommandLineRunner {
     return new CorsFilter(source);
   }
 
-  // Predefined admin user with full privileges
+  // Predefined admin, trader and basic users
   @Override
   public void run(String... params) throws Exception {
     User admin = new User();
@@ -61,14 +61,33 @@ public class Group6BackendService implements CommandLineRunner {
     admin.setEmail("admin@email.com");
     admin.setLatitude("46.123");
     admin.setLongitude("46.123");
-    admin.setStatus(RegistrationStatus.ENABLED);
+    admin.setRegistrationStatus(RegistrationStatus.ENABLED);
     admin.setRoles(new ArrayList<Role>(Arrays.asList(Role.ROLE_ADMIN)));
+    admin.setIsPrivate(true);
+    signupService.internal_signup(admin);
 
-    String token = signupService.admin_signup(admin);
+    User trader = new User();
+    trader.setUsername("trader");
+    trader.setPassword("trader");
+    trader.setEmail("trader@email.com");
+    trader.setLatitude("46.123");
+    trader.setIBAN("TR123456789012345678");
+    trader.setLongitude("46.123");
+    trader.setRegistrationStatus(RegistrationStatus.ENABLED);
+    trader.setRoles(new ArrayList<Role>(Arrays.asList(Role.ROLE_TRADER)));
+    trader.setIsPrivate(true);
+    signupService.internal_signup(trader);
 
-
-    hazelcastService.invalidateToken(token,"admin");
-
+    User basic = new User();
+    basic.setUsername("basic");
+    basic.setPassword("basic");
+    basic.setEmail("basic@email.com");
+    basic.setLatitude("46.123");
+    basic.setLongitude("46.123");
+    basic.setRegistrationStatus(RegistrationStatus.ENABLED);
+    basic.setRoles(new ArrayList<Role>(Arrays.asList(Role.ROLE_BASIC)));
+    basic.setIsPrivate(false);
+    signupService.internal_signup(basic);
 
   }
 

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/controller/LogoutController.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/controller/LogoutController.java
@@ -1,0 +1,48 @@
+package cmpe451.group6.authorization.controller;
+
+import cmpe451.group6.authorization.dto.StringResponseWrapper;
+import cmpe451.group6.authorization.dto.UserResponseDTO;
+import cmpe451.group6.authorization.exception.CustomException;
+import cmpe451.group6.authorization.model.User;
+import cmpe451.group6.authorization.repository.UserRepository;
+import cmpe451.group6.authorization.security.JwtTokenProvider;
+import cmpe451.group6.authorization.service.HazelcastService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/signout")
+@Api(tags = "Sign out")
+public class LogoutController {
+
+    @Autowired
+    JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    HazelcastService hazelcastService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @PostMapping("")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_BASIC') or hasRole('ROLE_TRADER')")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "Destroys the user token.")
+    public StringResponseWrapper logout(HttpServletRequest req) {
+        String token = jwtTokenProvider.resolveToken(req);
+        String username = userRepository.findByUsername(jwtTokenProvider.getUsername(token)).getUsername();
+        hazelcastService.invalidateToken(token,username);
+        return new StringResponseWrapper(String.format("Token <%s....> has been invalidated for the user @%s",
+                token.substring(0,10),username));
+    }
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/controller/PasswordController.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/controller/PasswordController.java
@@ -1,5 +1,7 @@
 package cmpe451.group6.authorization.controller;
 
+import cmpe451.group6.authorization.dto.LoginInfoDTO;
+import cmpe451.group6.authorization.dto.PasswordDTO;
 import cmpe451.group6.authorization.dto.StringResponseWrapper;
 import cmpe451.group6.authorization.exception.GlobalExceptionHandlerController;
 import cmpe451.group6.authorization.service.PasswordService;
@@ -36,23 +38,22 @@ public class PasswordController {
             @ApiResponse(code = 400, message = GlobalExceptionHandlerController.GENERIC_ERROR_RESPONSE),
             @ApiResponse(code = 403, message = "Invalid or expired Token")})
     public StringResponseWrapper renewPassword(
-                                @ApiParam("Token") @RequestParam String token,
-                                @ApiParam("Password") @RequestParam String newPassword) {
-
-        return new StringResponseWrapper(passwordService.setNewPassword(token,newPassword));
+            @ApiParam("New password and Token") @RequestBody PasswordDTO passwordDTO) {
+        return new StringResponseWrapper(passwordService.setNewPassword(passwordDTO.getToken()
+                ,passwordDTO.getNewPassword()));
     }
 
     @PostMapping("/change")
     @ResponseStatus(HttpStatus.OK)
     @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_BASIC') or hasRole('ROLE_TRADER')")
-    @ApiOperation(value = "Resets the password via user token.")
+    @ApiOperation(value = "Resets the password via user token. (without email)")
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = GlobalExceptionHandlerController.GENERIC_ERROR_RESPONSE),
             @ApiResponse(code = 403, message = "Invalid or expired Token"),
             @ApiResponse(code = 417, message = "Password does not conform to restrictions.")})
     public StringResponseWrapper changePassword(HttpServletRequest req,
-            @ApiParam("New Password") @RequestParam String newPassword) {
-        return new StringResponseWrapper(passwordService.changePassword(req,newPassword));
+            @ApiParam("New password. Leave token field empty.") @RequestBody PasswordDTO passwordDTO) {
+        return new StringResponseWrapper(passwordService.changePassword(req,passwordDTO.getNewPassword()));
     }
 
 

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/controller/UserController.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/controller/UserController.java
@@ -5,7 +5,9 @@ import javax.servlet.http.HttpServletRequest;
 import cmpe451.group6.authorization.dto.StringResponseWrapper;
 import cmpe451.group6.authorization.dto.TokenWrapperDTO;
 import cmpe451.group6.authorization.dto.UserResponseDTO;
+import cmpe451.group6.authorization.dto.PrivateProfileDTO;
 import cmpe451.group6.authorization.exception.GlobalExceptionHandlerController;
+import cmpe451.group6.authorization.model.User;
 import cmpe451.group6.authorization.service.UserService;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +19,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/users")
@@ -43,15 +47,15 @@ public class UserController {
     return new StringResponseWrapper(username);
   }
 
-  @GetMapping(value = "/{username}")
-  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @GetMapping(value = "/profile/{username}")
   @ResponseStatus(HttpStatus.OK)
-  @ApiOperation(value = "Gets profile of the given user (for admin user only).", response = UserResponseDTO.class)
+  @ApiOperation(value = "Gets profile of the given user.(No token required)", response = UserResponseDTO.class)
   @ApiResponses(value = {
       @ApiResponse(code = 400, message = "Something went wrong on the serverside"),
       @ApiResponse(code = 422, message = "The user doesn't exist")})
-  public UserResponseDTO search(@ApiParam("Username") @PathVariable String username) {
-    return modelMapper.map(userService.searchUser(username), UserResponseDTO.class);
+  public Object search(@ApiParam("Username") @PathVariable String username) {
+    User user = userService.searchUser(username);
+    return modelMapper.map(user, user.getIsPrivate() ? PrivateProfileDTO.class : UserResponseDTO.class);
   }
 
   @GetMapping(value = "/me")
@@ -73,5 +77,26 @@ public class UserController {
     return userService.refreshToken(req.getRemoteUser(),req);
   }
 
+  @PostMapping("/set_profile/private")
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_BASIC') or hasRole('ROLE_TRADER')")
+  @ApiOperation(value = "Make senders profile private.", response = String.class)
+  public StringResponseWrapper makePrivate(HttpServletRequest req) {
+    return new StringResponseWrapper(userService.setPrivate(req));
+  }
 
+  @PostMapping("/set_profile/public")
+  @ResponseStatus(HttpStatus.OK)
+  @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_BASIC') or hasRole('ROLE_TRADER')")
+  @ApiOperation(value = "Make senders profile public.", response = String.class)
+  public StringResponseWrapper makePublic(HttpServletRequest req) {
+    return new StringResponseWrapper(userService.setPublic(req));
+  }
+
+  @PostMapping("/getAll")
+  @ResponseStatus(HttpStatus.OK)
+  @ApiOperation(value = "Returns all user profiles (Limited by 20 for now, No token required).", response = String.class)
+  public List<Object> getAll(HttpServletRequest req) {
+    return userService.getAll();
+  }
 }

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/controller/UserController.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/controller/UserController.java
@@ -93,7 +93,7 @@ public class UserController {
     return new StringResponseWrapper(userService.setPublic(req));
   }
 
-  @PostMapping("/getAll")
+  @GetMapping("/getAll")
   @ResponseStatus(HttpStatus.OK)
   @ApiOperation(value = "Returns all user profiles (Limited by 20 for now, No token required).", response = String.class)
   public List<Object> getAll(HttpServletRequest req) {

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/dto/PasswordDTO.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/dto/PasswordDTO.java
@@ -1,0 +1,29 @@
+package cmpe451.group6.authorization.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class PasswordDTO {
+
+    @ApiModelProperty(position = 0,required = true)
+    private String token;
+
+    @ApiModelProperty(position = 1)
+    private String newPassword;
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
+    }
+
+    public void setNewPassword(String newPassword) {
+        this.newPassword = newPassword;
+    }
+}
+

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/dto/PrivateProfileDTO.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/dto/PrivateProfileDTO.java
@@ -1,0 +1,42 @@
+package cmpe451.group6.authorization.dto;
+
+import cmpe451.group6.authorization.model.Role;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.List;
+
+public class PrivateProfileDTO {
+
+    @ApiModelProperty(position = 0,required = true)
+    private String username;
+
+    @ApiModelProperty(position = 1)
+    List<Role> roles;
+
+    @ApiModelProperty(position = 2)
+    boolean isPrivate;
+
+    public boolean isPrivate() {
+        return isPrivate;
+    }
+
+    public void setPrivate(boolean aPrivate) {
+        isPrivate = aPrivate;
+    }
+
+    public List<Role> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(List<Role> roles) {
+        this.roles = roles;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/dto/PrivateProfileDTO.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/dto/PrivateProfileDTO.java
@@ -7,20 +7,20 @@ import java.util.List;
 
 public class PrivateProfileDTO {
 
-    @ApiModelProperty(position = 0,required = true)
+    @ApiModelProperty(position = 0)
     private String username;
 
     @ApiModelProperty(position = 1)
-    List<Role> roles;
+    private List<Role> roles;
 
     @ApiModelProperty(position = 2)
-    boolean isPrivate;
+    private boolean isPrivate;
 
-    public boolean isPrivate() {
+    public boolean getIsPrivate() {
         return isPrivate;
     }
 
-    public void setPrivate(boolean aPrivate) {
+    public void setIsPrivate(boolean aPrivate) {
         isPrivate = aPrivate;
     }
 

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/dto/UserDataDTO.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/dto/UserDataDTO.java
@@ -19,6 +19,20 @@ public class UserDataDTO {
   private String latitude;
   @ApiModelProperty(position = 5,required = true)
   private String longitude;
+  @ApiModelProperty(position = 6)
+  private boolean isPrivate;
+
+
+  // NOTE : DO NOT CHANGE GETTER and SETTER SIGNATURES FOR THIS FIELD !!
+  // Because the mapper seeks the getter & setter fields by these names,
+  // not with "isPrivate()" or "setPrivate(boolean _)"
+  public boolean getIsPrivate() {
+    return isPrivate;
+  }
+
+  public void setIsPrivate(boolean aPrivate) {
+    isPrivate = aPrivate;
+  }
 
   public String getLongitude() { return longitude; }
 

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/dto/UserResponseDTO.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/dto/UserResponseDTO.java
@@ -8,19 +8,30 @@ import io.swagger.annotations.ApiModelProperty;
 public class UserResponseDTO {
 
   @ApiModelProperty(position = 0)
-  private Integer id;
-  @ApiModelProperty(position = 1)
   private String username;
-  @ApiModelProperty(position = 2)
+  @ApiModelProperty(position = 1)
   private String email;
-  @ApiModelProperty(position = 3)
+  @ApiModelProperty(position = 2)
   private String IBAN;
-  @ApiModelProperty(position = 4)
+  @ApiModelProperty(position = 3)
   private String latitude;
-  @ApiModelProperty(position = 5)
+  @ApiModelProperty(position = 4)
   private String longitude;
-  @ApiModelProperty(position = 6)
+  @ApiModelProperty(position = 5)
   List<Role> roles;
+  @ApiModelProperty(position = 6)
+  private boolean isPrivate;
+
+  // NOTE : DO NOT CHANGE GETTER and SETTER SIGNATURES FOR THIS FIELD !!
+  // Because the mapper seeks the getter & setter fields by these names,
+  // not with "isPrivate()" or "setPrivate(boolean _)"
+  public boolean getIsPrivate() {
+    return isPrivate;
+  }
+
+  public void setIsPrivate(boolean aPrivate) {
+    isPrivate = aPrivate;
+  }
 
   public String getLatitude() { return latitude; }
 
@@ -33,10 +44,6 @@ public class UserResponseDTO {
   public String getIBAN() { return IBAN; }
 
   public void setIBAN(String IBAN) { this.IBAN = IBAN; }
-
-  public Integer getId() { return id; }
-
-  public void setId(Integer id) { this.id = id; }
 
   public String getUsername() { return username; }
 

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/model/User.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/model/User.java
@@ -10,7 +10,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
 
 @Entity
 public class User {
@@ -47,6 +46,8 @@ public class User {
   @Pattern(regexp = locationRegex)
   private String longitude;
 
+
+
   //   ^               # start-of-string
   // (?=.*[0-9])       # a digit must occur at least once
   // (?=.*[a-z])       # a lower case letter must occur at least once
@@ -62,14 +63,29 @@ public class User {
   List<Role> roles;
 
   @Column(nullable = false)
-  private RegistrationStatus status;
+  private RegistrationStatus registrationStatus;
 
-  public RegistrationStatus getStatus() {
-    return status;
+  @Column(nullable = false)
+  private boolean isPrivate;
+
+  // NOTE : DO NOT CHANGE GETTER and SETTER SIGNATURES FOR THIS FIELD !!
+  // Because the mapper seeks the getter & setter fields by these names,
+  // not with "isPrivate()" or "setPrivate(boolean _)"
+  public boolean getIsPrivate() {
+    return isPrivate;
   }
 
-  public void setStatus(RegistrationStatus status) {
-    this.status = status;
+  public void setIsPrivate(boolean aPrivate) {
+    isPrivate = aPrivate;
+  }
+
+
+  public RegistrationStatus getRegistrationStatus() {
+    return registrationStatus;
+  }
+
+  public void setRegistrationStatus(RegistrationStatus registrationStatus) {
+    this.registrationStatus = registrationStatus;
   }
 
   public String getLatitude() {

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/repository/UserRepository.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/repository/UserRepository.java
@@ -5,6 +5,8 @@ import javax.transaction.Transactional;
 import cmpe451.group6.authorization.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface UserRepository extends JpaRepository<User, Integer> {
 
   boolean existsByUsername(String username);
@@ -14,6 +16,8 @@ public interface UserRepository extends JpaRepository<User, Integer> {
   User findByUsername(String username);
 
   User findByEmail(String email);
+
+  List<Object> getUsersByIdLessThan(int limit);
 
   @Transactional
   void deleteByUsername(String username);

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/security/JwtTokenFilter.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/security/JwtTokenFilter.java
@@ -73,7 +73,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
         User user = userRepository.findByUsername(jwtTokenProvider.getUsername(token));
 
         // Check if user has been activated the account via Email or Google
-        if(user.getStatus() == RegistrationStatus.PENDING){
+        if(user.getRegistrationStatus() == RegistrationStatus.PENDING){
           // account is not validated yet. Return error response.
 
           // Comment out the next line if you want to disable verification via mail. (FOR THE EASE OF DEVELOPMENT ONLY)

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/security/WebSecurityConfig.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/security/WebSecurityConfig.java
@@ -36,9 +36,10 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         .antMatchers("/password/forgot").permitAll()
         .antMatchers("/password/renew").permitAll()
         .antMatchers("/signup/confirm").permitAll()
-
+        .antMatchers("/users/profile/**").permitAll()
         .antMatchers("/h2-console/**/**").permitAll()
         .antMatchers("/trial/public").permitAll()
+            .antMatchers("/users/getAll").permitAll()
         // Disallow everything else..
         .anyRequest().authenticated();
 
@@ -59,6 +60,15 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         .antMatchers("/configuration/**")//
         .antMatchers("/webjars/**")//
         .antMatchers("/public")
+        .antMatchers("/login")
+        .antMatchers("/signup")
+        .antMatchers("/password/forgot")
+        .antMatchers("/password/renew")
+        .antMatchers("/signup/confirm")
+        .antMatchers("/users/profile/**")
+        .antMatchers("/h2-console/**/**")
+        .antMatchers("/trial/public")
+        .antMatchers("/users/getAll")
         
         // Un-secure H2 Database (for testing purposes, H2 console shouldn't be unprotected in production)
         .and()

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/PasswordService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/PasswordService.java
@@ -34,11 +34,14 @@ public class PasswordService {
     @Autowired
     private HazelcastService hazelcastService;
 
-    @Value("${server.url}")
+    @Value("${email.frontend_url}")
     private String baseURL;
 
-    @Value("${server.port}")
+    @Value("${email.frontend_port}")
     private String port;
+
+    @Value("${email.frontend_reset_path}")
+    private String path;
 
     public String sendRenewalMail(String mail){
         User user = userRepository.findByEmail(mail);
@@ -51,7 +54,7 @@ public class PasswordService {
                 throw new CustomException(String.format("Failed to send verification email to the address: %s", mail) , HttpStatus.INTERNAL_SERVER_ERROR);
             }
 
-            return "Link to reset password has been sent to your email.";
+            return "Link to reset password has been sent to "+ mail;
         } else {
             throw new CustomException("No user found for the email", HttpStatus.BAD_REQUEST);
         }
@@ -81,7 +84,8 @@ public class PasswordService {
     }
 
     private String buildPasswordRenewalURL(String token){
-        return baseURL+":"+port+"/users/renew?token=" + token;
+        System.out.println(baseURL+":"+port+"/"+path+"?token="+token);
+        return baseURL+":"+port+"/"+path+"?token="+token;
     }
 
 }

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/SignupService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/SignupService.java
@@ -49,7 +49,7 @@ public class SignupService {
             user.setPassword(passwordEncoder.encode(user.getPassword()));
             Role role = validateIBAN(user.getIBAN());
             user.setRoles(new ArrayList<>(Arrays.asList(role)));
-            user.setStatus(RegistrationStatus.PENDING);
+            user.setRegistrationStatus(RegistrationStatus.PENDING);
             String token = jwtTokenProvider.createToken(user.getUsername(), user.getRoles());
 
             try {
@@ -70,7 +70,7 @@ public class SignupService {
         try {
             String username = jwtTokenProvider.getUsername(token);
             User user = userRepository.findByUsername(username);
-            user.setStatus(RegistrationStatus.ENABLED);
+            user.setRegistrationStatus(RegistrationStatus.ENABLED);
             userRepository.save(user);
             hazelcastService.invalidateToken(token, username);
             return "Confirmation completed";
@@ -79,7 +79,7 @@ public class SignupService {
         }
     }
 
-    public String admin_signup(User user){
+    public String internal_signup(User user){
         if (!userRepository.existsByUsername(user.getUsername())) {
             user.setPassword(passwordEncoder.encode(user.getPassword()));
             userRepository.save(user);

--- a/backend/TraderX/src/main/resources/application.yml
+++ b/backend/TraderX/src/main/resources/application.yml
@@ -35,3 +35,11 @@ security:
 email:
   sender_address: "bounswegroup6@gmail.com"
   sender_password: "*********"
+
+  # Reset link is active on the backend side and waiting for a frontend page
+  # to make user able to enter new pw and send that pw with token to
+  # /renew endpoint on backend side.
+  frontend_url: http://localhost # To which reset password link will redirect clients
+  frontend_port: 9999 # TBD
+  frontend_reset_path: renew_password # TBD, up to frontend team
+


### PR DESCRIPTION
Some remarkable changes:

- User profiles now have private option. If a profile is private, only username and the user role are shown.

- `GET` to `/users/profile/{username}` endpoint is now public. Anyone can get the restricted user profile data.

- A user can set his profile public/private via sending `POST` to  `users/set_profile/private` or  `users/set_profile/public` with token.

- `GET` to `/users/getAll` endpoint is created and its public. It returns up to 20 (max) users' restricted profile data. This endpoint is not permanent and for the ease of development for frontend & android devs.

- During a sign up process, if `"isPrivate" : true` field is supplied in the request body then the profile will be set accordingly. If it does not exist or is set `false`, the profile will be public.

- `POST` to `/signout` invalidates the client token.

- Resetting password logic has been changed. When a request is sent to `/password/forgot` path, 
a link which directs client to a frontend page (to be implemented @irmakguzey @sadullahgultekin @burakyuksel0 ) with given token is sent. Then user will enter its new password using frontend page and another request with the body containing token and password will be sent to `/renew` endpoint to set new pw. Android side(@msdalp @bwqr @barandenizkorkmaz ) may use a web viewer or sth for this.