### PR TITLE
Add Google token fields 

### DIFF
--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/controller/LoginController.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/controller/LoginController.java
@@ -24,7 +24,9 @@ public class LoginController {
     @ApiOperation(value = "Login Operations")
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = GlobalExceptionHandlerController.GENERIC_ERROR_RESPONSE),
-            @ApiResponse(code = 401, message = "Invalid username and password pair.")})
+            @ApiResponse(code = 401, message = "Invalid username and password pair."),
+            @ApiResponse(code = 406, message = "Supply only one of the credentials : password or token."),
+            @ApiResponse(code = 410, message = "No such user.")})
     public TokenWrapperDTO login(
             @ApiParam("User Credentials") @RequestBody LoginInfoDTO loginInfoDTO) {
         return loginService.login(loginInfoDTO);

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/controller/SignupController.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/controller/SignupController.java
@@ -41,7 +41,7 @@ public class SignupController {
                 @ApiResponse(code = 412, message = "Value does not match regex."),
                 @ApiResponse(code = 500, message = "Failed to send verification email.")})
         public StringResponseWrapper signup(@ApiParam("Signup User") @RequestBody UserDataDTO user) {
-            return new StringResponseWrapper(signupService.signup(modelMapper.map(user, User.class)));
+            return new StringResponseWrapper(signupService.signup(modelMapper.map(user, User.class),user.getAppSecret()));
         }
 
 }

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/dto/LoginInfoDTO.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/dto/LoginInfoDTO.java
@@ -7,8 +7,19 @@ public class LoginInfoDTO {
     @ApiModelProperty(position = 0,required = true)
     private String username;
 
-    @ApiModelProperty(position = 1,required = true)
+    @ApiModelProperty(position = 1)
     private String password;
+
+    @ApiModelProperty(position = 2)
+    private String googleToken;
+
+    public String getGoogleToken() {
+        return googleToken;
+    }
+
+    public void setGoogleToken(String googleToken) {
+        this.googleToken = googleToken;
+    }
 
     public String getUsername() {
         return username;

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/dto/UserDataDTO.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/dto/UserDataDTO.java
@@ -11,7 +11,7 @@ public class UserDataDTO {
   private String username;
   @ApiModelProperty(position = 1,required = true)
   private String email;
-  @ApiModelProperty(position = 2,required = true)
+  @ApiModelProperty(position = 2)
   private String password;
   @ApiModelProperty(position = 3)
   private String IBAN;
@@ -21,6 +21,8 @@ public class UserDataDTO {
   private String longitude;
   @ApiModelProperty(position = 6)
   private boolean isPrivate;
+  @ApiModelProperty(position = 7)
+  private String googleToken;
 
 
   // NOTE : DO NOT CHANGE GETTER and SETTER SIGNATURES FOR THIS FIELD !!

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/dto/UserDataDTO.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/dto/UserDataDTO.java
@@ -23,7 +23,25 @@ public class UserDataDTO {
   private boolean isPrivate;
   @ApiModelProperty(position = 7)
   private String googleToken;
+  @ApiModelProperty(position = 8)
+  private String appSecret;
 
+
+  public String getAppSecret() {
+    return appSecret;
+  }
+
+  public void setAppSecret(String appSecret) {
+    this.appSecret = appSecret;
+  }
+
+  public String getGoogleToken() {
+    return googleToken;
+  }
+
+  public void setGoogleToken(String googleToken) {
+    this.googleToken = googleToken;
+  }
 
   // NOTE : DO NOT CHANGE GETTER and SETTER SIGNATURES FOR THIS FIELD !!
   // Because the mapper seeks the getter & setter fields by these names,

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/model/User.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/model/User.java
@@ -68,6 +68,17 @@ public class User {
   @Column(nullable = false)
   private boolean isPrivate;
 
+  @Column
+  private String googleToken;
+
+  public String getGoogleToken() {
+    return googleToken;
+  }
+
+  public void setGoogleToken(String googleToken) {
+    this.googleToken = googleToken;
+  }
+
   // NOTE : DO NOT CHANGE GETTER and SETTER SIGNATURES FOR THIS FIELD !!
   // Because the mapper seeks the getter & setter fields by these names,
   // not with "isPrivate()" or "setPrivate(boolean _)"

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/LoginService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/LoginService.java
@@ -4,6 +4,7 @@ package cmpe451.group6.authorization.service;
 import cmpe451.group6.authorization.dto.LoginInfoDTO;
 import cmpe451.group6.authorization.dto.TokenWrapperDTO;
 import cmpe451.group6.authorization.exception.CustomException;
+import cmpe451.group6.authorization.model.User;
 import cmpe451.group6.authorization.repository.UserRepository;
 import cmpe451.group6.authorization.security.JwtTokenProvider;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,9 +54,8 @@ public class LoginService {
                 throw new CustomException("Invalid username/password supplied", HttpStatus.UNAUTHORIZED);
             }
         } else { // Check if google tokes are matched
-            if (user.getGoogleToken() == googleToken)
+            if (user.getGoogleToken().equals(googleToken))
                 return new TokenWrapperDTO(jwtTokenProvider.createToken(username, user.getRoles()));
-
             throw new CustomException("Invalid Google Token supplied", HttpStatus.UNAUTHORIZED);
         }
     }

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/PasswordService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/PasswordService.java
@@ -84,7 +84,6 @@ public class PasswordService {
     }
 
     private String buildPasswordRenewalURL(String token){
-        System.out.println(baseURL+":"+port+"/"+path+"?token="+token);
         return baseURL+":"+port+"/"+path+"?token="+token;
     }
 

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/SignupService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/SignupService.java
@@ -61,8 +61,12 @@ public class SignupService {
 
             boolean isGoogleUser = user.getPassword() == null;
 
-            if(isGoogleUser && !appSecret.equals(this.appSecret)){
-                throw new CustomException("Wrong App Secret", HttpStatus.UNAUTHORIZED);
+            if(isGoogleUser){
+                if(appSecret == null)
+                    throw new CustomException("Null app secret.", HttpStatus.UNAUTHORIZED);
+
+                if(!appSecret.equals(this.appSecret))
+                    throw new CustomException("Wrong App Secret", HttpStatus.UNAUTHORIZED);
             }
 
             Role role = validateIBAN(user.getIBAN());
@@ -139,18 +143,16 @@ public class SignupService {
         if (user.getUsername() == null || !user.getUsername().matches(User.usernameRegex)) {
             throw new CustomException("Invalid username", HttpStatus.PRECONDITION_FAILED);
         }
-        /*
-        if (user.getPassword() == null || !user.getPassword().matches(User.passwordRegex)) {
-            throw new CustomException("Invalid password", HttpStatus.PRECONDITION_FAILED);
-        }*/
         if (user.getPassword() == null && user.getGoogleToken() == null) {
+            // Supply only one authentication credential
             throw new CustomException("Supply password or google token", HttpStatus.PRECONDITION_FAILED);
         }
         if (user.getPassword() != null && user.getGoogleToken() != null) {
+            // Supply only one authentication credential
             throw new CustomException("Supply only one of those: password or google token", HttpStatus.PRECONDITION_FAILED);
         }
         if (user.getPassword() != null && !user.getPassword().matches(User.passwordRegex)) {
-            throw new CustomException("Supply password or google token", HttpStatus.PRECONDITION_FAILED);
+            throw new CustomException("Invalid password", HttpStatus.PRECONDITION_FAILED);
         }
         if (user.getEmail() == null || !user.getEmail().matches(User.emailRegex)) {
             throw new CustomException("Invalid email", HttpStatus.PRECONDITION_FAILED);

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/SignupService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/service/SignupService.java
@@ -49,15 +49,21 @@ public class SignupService {
     @Value("${email.frontend_verification_path}")
     private String verificationPath;
 
+    @Value("${security.jwt.token.secret-key}")
+    private String appSecret;
 
 
-    public String signup(User user) {
+    public String signup(User user, String appSecret) {
         if (!userRepository.existsByUsername(user.getUsername()) && !userRepository.existsByEmail(user.getEmail())) {
 
             // Check field validity. Throw exception and return error if at least one of them is wrong
             validateUserData(user);
 
-            boolean isGoogleUser = user.getPassword == null;
+            boolean isGoogleUser = user.getPassword() == null;
+
+            if(isGoogleUser && !appSecret.equals(this.appSecret)){
+                throw new CustomException("Wrong App Secret", HttpStatus.UNAUTHORIZED);
+            }
 
             Role role = validateIBAN(user.getIBAN());
             user.setRoles(new ArrayList<>(Arrays.asList(role)));

--- a/backend/TraderX/src/main/resources/application.yml
+++ b/backend/TraderX/src/main/resources/application.yml
@@ -42,4 +42,5 @@ email:
   frontend_url: http://localhost # To which reset password link will redirect clients
   frontend_port: 9999 # TBD
   frontend_reset_path: renew_password # TBD, up to frontend team
+  frontend_verification_path : verification_path
 


### PR DESCRIPTION
Android (@barandenizkorkmaz @msdalp @bwqr ) and frontend (@sadullahgultekin @burakyuksel0 @irmakguzey) teams please be aware of the new features.

This PR does not break any sign up or login behavior from the previous commits. 

- During sign up process, if a user to be registered via Google, send a `googleToken` in your request body and do not include `password` field. Otherwise server will respond error.   
- This token has to be taken from Google using user credentials. Currently, there is no check for this token if it's valid for this user. Instead, this is expected to be done on frontend & android side.
- In order to prevent fake google tokens for signing up, you have to include `appSecret` field on request body. This secret is constant.

So, to sign up via google, send such a request to `/signup` as it was:
```json
{
	"username" : "some-username",
	"googleToken" : "token-for-user",
	"latitude" : "23.1",
	"longitude" : "23.1",
	"email" : "user@gmail.com",
	"appSecret": "constant-secret-key",
        "optional-fields": "optional-values"
}
```

To log in with Google, fetch token from Google and send this request to `login` as it was:
```json
{
	"username" : "some-username",
	"googleToken" : "token-for-user"
}
```

