### PR TITLE
Approval mechanism for "following" relation changed

### DIFF
--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/follow/service/FollowService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/follow/service/FollowService.java
@@ -55,10 +55,19 @@ public class FollowService {
         FollowDAO temp = new FollowDAO();
         temp.setFollower(currentUser);
         temp.setFollowee(userToFollow);
-        temp.setFollowStatus(FollowStatus.PENDING);
+
+        String followStatus ;
+        if (userToFollow.getIsPrivate()) {
+            followStatus = " wants to follow ";
+            temp.setFollowStatus(FollowStatus.PENDING);
+        } else {
+            followStatus = " is now following ";
+            temp.setFollowStatus(FollowStatus.APPROVED);
+        }
 
         followRepository.save(temp);
-        return String.format("%s want to follow %s", currentUser.getUsername(), userToFollow.getUsername());
+        return (currentUser.getUsername() + followStatus + userToFollow.getUsername());        
+        
     }
 
     /**


### PR DESCRIPTION
**Goal of this PR:** 

When a user tries to follow a **public user**, follow relation will be set as APPROVED as the request is sent,
On the other hand, When a user tries to follow a private user, follow relation will be set as PENDING as the request is sent (Approval of the followee is needed )


