### PR TITLE
Frontend portfolio

### DIFF
--- a/frontend/TraderX/src/api/equipment.js
+++ b/frontend/TraderX/src/api/equipment.js
@@ -20,3 +20,17 @@ export function getAllCurrencies() {
     method: 'get'
   })
 }
+
+export function getAllCryptoCurrencies() {
+  return request({
+    url: '/equipment/crypto-currency/list',
+    method: 'get'
+  })
+}
+
+export function getAllStocks() {
+  return request({
+    url: '/equipment/stock/list',
+    method: 'get'
+  })
+}

--- a/frontend/TraderX/src/api/equipment.js
+++ b/frontend/TraderX/src/api/equipment.js
@@ -13,3 +13,10 @@ export function getEquipment(equipmentName) {
     method: 'get'
   })
 }
+
+export function getAllCurrencies() {
+  return request({
+    url: '/equipment/currency/list',
+    method: 'get'
+  })
+}

--- a/frontend/TraderX/src/components/CoolCard/index.vue
+++ b/frontend/TraderX/src/components/CoolCard/index.vue
@@ -2,7 +2,7 @@
   <div class="wrapper">
     <div class="cols">
         <div class="col" ontouchstart="this.classList.toggle('hover');" v-for="portfolio in this.cardData"  v-bind:key="portfolio">
-          <div class="container">
+          <div class="container" @click="goToPortfolio(portfolio.portfolioName)">
             <div class="front" style="background-image: url(https://unsplash.it/502/502/)">
               <div class="inner">
                 <p>{{ portfolio.portfolioName }}</p>
@@ -26,6 +26,11 @@ export default {
   props: {
     cardData : Array
   },
+  methods: {
+    goToPortfolio(portfolioName) {
+      this.$router.push({ path: `/portfolio/${portfolioName}` })
+    },
+  }
 }
     
 </script>

--- a/frontend/TraderX/src/components/CoolCard/index.vue
+++ b/frontend/TraderX/src/components/CoolCard/index.vue
@@ -3,13 +3,13 @@
     <div class="cols">
         <div class="col" ontouchstart="this.classList.toggle('hover');" v-for="portfolio in this.cardData"  v-bind:key="portfolio">
           <div class="container" @click="goToPortfolio(portfolio.portfolioName)">
-            <div class="front" style="background-image: url(https://unsplash.it/502/502/)">
+            <div class="front" style="background-image: url(https://picsum.photos/id/93/502/502)">
               <div class="inner">
                 <p>{{ portfolio.portfolioName }}</p>
                 <!-- <span>Lorem ipsum</span> -->
               </div>
             </div>
-            <div class="back">
+            <div class="back" style="background-image: url(https://picsum.photos/id/93/502/502)">
               <div class="inner">
                 <p>{{ portfolio.portfolioDescription }}</p>
               </div>

--- a/frontend/TraderX/src/components/CoolCard/index.vue
+++ b/frontend/TraderX/src/components/CoolCard/index.vue
@@ -24,11 +24,12 @@
 
 export default {
   props: {
-    cardData : Array
+    cardData : Array,
+    username: String
   },
   methods: {
     goToPortfolio(portfolioName) {
-      this.$router.push({ path: `/portfolio/${portfolioName}` })
+      this.$router.push({ path: `/portfolio/${this.username}/${portfolioName}` })
     },
   }
 }

--- a/frontend/TraderX/src/layout/index.vue
+++ b/frontend/TraderX/src/layout/index.vue
@@ -1,5 +1,6 @@
 <template>
   <div :class="classObj" class="app-wrapper">
+    <github-corner class="github-corner" style="margin-top: 50px"/>
     <div v-if="device==='mobile'&&sidebar.opened" class="drawer-bg" @click="handleClickOutside" />
     <sidebar class="sidebar-container" />
     <div :class="{hasTagsView:needTagsView}" class="main-container">
@@ -16,6 +17,7 @@
 </template>
 
 <script>
+import GithubCorner from '@/components/GithubCorner'
 import RightPanel from '@/components/RightPanel'
 import { AppMain, Navbar, Settings, Sidebar, TagsView } from './components'
 import ResizeMixin from './mixin/ResizeHandler'
@@ -24,6 +26,7 @@ import { mapState } from 'vuex'
 export default {
   name: 'Layout',
   components: {
+    GithubCorner,
     AppMain,
     Navbar,
     RightPanel,

--- a/frontend/TraderX/src/router/index.js
+++ b/frontend/TraderX/src/router/index.js
@@ -190,10 +190,9 @@ export const constantRoutes = [
     ]
   },
   {
-    // path: '/user/:username/profile',
-    path: '/portfolio/:portfolioname',
+    path: '/portfolio/:username/:portfolioname',
     component: Layout,
-    redirect: '/portfolio/:portfolioname',
+    redirect: '/portfolio/:username/:portfolioname',
     hidden: true,
     children: [
       {

--- a/frontend/TraderX/src/router/index.js
+++ b/frontend/TraderX/src/router/index.js
@@ -189,6 +189,21 @@ export const constantRoutes = [
       }
     ]
   },
+  {
+    // path: '/user/:username/profile',
+    path: '/portfolio/:portfolioname',
+    component: Layout,
+    redirect: '/portfolio/:portfolioname',
+    hidden: true,
+    children: [
+      {
+        path: '',
+        component: () => import('@/views/portfolio/index'),
+        name: 'Portfolio',
+        meta: { title: 'Portfolio', noCache: true },
+      }
+    ]
+  },
 
 ]
 

--- a/frontend/TraderX/src/store/getters.js
+++ b/frontend/TraderX/src/store/getters.js
@@ -8,6 +8,7 @@ const getters = {
   userInfo: state => state.user.userInfo,
   userSearchResult: state => state.search.userSearchResult,
   equipmentQueryResult: state => state.equipment.equipmentQueryResult,
+  currencyResult: state => state.equipment.currencyResult,
 
   // TODO these are deprecated but we can keep useful ones
   roles: state => state.user.roles,

--- a/frontend/TraderX/src/store/getters.js
+++ b/frontend/TraderX/src/store/getters.js
@@ -9,6 +9,8 @@ const getters = {
   userSearchResult: state => state.search.userSearchResult,
   equipmentQueryResult: state => state.equipment.equipmentQueryResult,
   currencyResult: state => state.equipment.currencyResult,
+  cryptoCurrencyResult: state => state.equipment.cryptoCurrencyResult,
+  stockResult: state => state.equipment.stockResult,
 
   // TODO these are deprecated but we can keep useful ones
   roles: state => state.user.roles,

--- a/frontend/TraderX/src/store/modules/equipment.js
+++ b/frontend/TraderX/src/store/modules/equipment.js
@@ -1,4 +1,4 @@
-import { getEquipment, listEquipment } from '@/api/equipment'
+import { getEquipment, listEquipment, getAllCurrencies} from '@/api/equipment'
 
 const state = {
   equipmentQueryResult : {
@@ -9,6 +9,9 @@ const state = {
 const mutations = {
   SET_QUERY_RESULT: (state, result) => {
     state.equipmentQueryResult = result
+  },
+  SET_CURRENCY_RESULT: (state, result) => {
+    state.currencyResult = result
   }
 }
 
@@ -29,6 +32,17 @@ const actions = {
       listEquipment().then(response => {
         const { data } = response
         commit('SET_QUERY_RESULT', data)
+        resolve()
+      }).catch(error => {
+        reject(error)
+      })
+    })
+  },
+  getAllCurrencies({ commit }) {
+    return new Promise((resolve, reject) => {
+        getAllCurrencies().then(response => {
+        const { data } = response
+        commit('SET_CURRENCY_RESULT', data)
         resolve()
       }).catch(error => {
         reject(error)

--- a/frontend/TraderX/src/store/modules/equipment.js
+++ b/frontend/TraderX/src/store/modules/equipment.js
@@ -1,4 +1,4 @@
-import { getEquipment, listEquipment, getAllCurrencies} from '@/api/equipment'
+import { getEquipment, listEquipment, getAllCurrencies, getAllCryptoCurrencies, getAllStocks} from '@/api/equipment'
 
 const state = {
   equipmentQueryResult : {
@@ -12,6 +12,12 @@ const mutations = {
   },
   SET_CURRENCY_RESULT: (state, result) => {
     state.currencyResult = result
+  },
+  SET_CRYPTO_CURRENCY_RESULT: (state, result) => {
+    state.cryptoCurrencyResult = result
+  },
+  SET_STOCK_RESULT: (state, result) => {
+    state.stockResult = result
   }
 }
 
@@ -43,6 +49,28 @@ const actions = {
         getAllCurrencies().then(response => {
         const { data } = response
         commit('SET_CURRENCY_RESULT', data)
+        resolve()
+      }).catch(error => {
+        reject(error)
+      })
+    })
+  },
+  getAllCryptoCurrencies({ commit }) {
+    return new Promise((resolve, reject) => {
+        getAllCryptoCurrencies().then(response => {
+        const { data } = response
+        commit('SET_CRYPTO_CURRENCY_RESULT', data)
+        resolve()
+      }).catch(error => {
+        reject(error)
+      })
+    })
+  },
+  getAllStocks({ commit }) {
+    return new Promise((resolve, reject) => {
+        getAllStocks().then(response => {
+        const { data } = response
+        commit('SET_STOCK_RESULT', data)
         resolve()
       }).catch(error => {
         reject(error)

--- a/frontend/TraderX/src/views/dashboard/admin/index.vue
+++ b/frontend/TraderX/src/views/dashboard/admin/index.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="dashboard-editor-container">
-    <github-corner class="github-corner" />
 
     <panel-group @handleSetLineChartData="handleSetLineChartData" />
 
@@ -41,7 +40,6 @@
 </template>
 
 <script>
-import GithubCorner from '@/components/GithubCorner'
 import PanelGroup from './components/PanelGroup'
 import LineChart from './components/LineChart'
 import RaddarChart from './components/RaddarChart'
@@ -73,7 +71,6 @@ const lineChartData = {
 export default {
   name: 'DashboardAdmin',
   components: {
-    GithubCorner,
     PanelGroup,
     LineChart,
     RaddarChart,

--- a/frontend/TraderX/src/views/portfolio/index.vue
+++ b/frontend/TraderX/src/views/portfolio/index.vue
@@ -38,7 +38,7 @@
 
 <script>
 
-import { getAllCurrencies } from '@/api/equipment'
+import { getAllCurrencies, getAllCryptoCurrencies, getAllStocks } from '@/api/equipment'
 
 export default {
   data() {
@@ -51,12 +51,31 @@ export default {
   },
   async created() {
     this.currencyTableData = await this.getCurrency()
+    this.cryptoCurrencyTableData = await this.getCryptoCurrency()
+    this.stockTableData = await this.getStock()
   },
   methods: {
     async getCurrency() {
       await this.$store.dispatch('equipment/getAllCurrencies').then(response =>{
         var res = this.$store.getters.currencyResult
-        console.log("here")
+        console.log(res)
+      }).catch(error => {
+        console.log(error)
+      })
+      return 
+    },
+    async getCryptoCurrency() {
+      await this.$store.dispatch('equipment/getAllCryptoCurrencies').then(response =>{
+        var res = this.$store.getters.cryptoCurrencyResult
+        console.log(res)
+      }).catch(error => {
+        console.log(error)
+      })
+      return 
+    },
+    async getStock() {
+      await this.$store.dispatch('equipment/getAllStocks').then(response =>{
+        var res = this.$store.getters.stockResult
         console.log(res)
       }).catch(error => {
         console.log(error)

--- a/frontend/TraderX/src/views/portfolio/index.vue
+++ b/frontend/TraderX/src/views/portfolio/index.vue
@@ -77,7 +77,7 @@ export default {
     }
   },
   async created() {
-    this.portfolioname = this.$route.path.split('/')[2].toUpperCase()
+    this.portfolioname = this.$route.path.split('/')[3].toUpperCase()
     await this.getCurrency()
     await this.getCryptoCurrency()
     await this.getStock()

--- a/frontend/TraderX/src/views/portfolio/index.vue
+++ b/frontend/TraderX/src/views/portfolio/index.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="app-container">
+    <div style="margin-top: 30px; margin-bottom: 50px; margin-left: 60px; margin-right: 60px">
+      <el-collapse v-model="activeNames">
+
+        <el-collapse-item title="Currency" name="1">
+          <el-table ref="multipleCurrencyTable" :data="currencyTableData" style="width: 100%" @selection-change="handleSelectionChange">
+            <el-table-column type="selection"></el-table-column>
+            <el-table-column label="Equipment Name">
+              <template slot-scope="scope">{{ scope.row.equipments }}</template>
+            </el-table-column>
+          </el-table>
+        </el-collapse-item>
+
+        <el-collapse-item title="Crypto-Currency" name="2">
+          <el-table ref="multipleCryptoCurrencyTable" :data="cryptoCurrencyTableData" style="width: 100%" @selection-change="handleSelectionChange">
+            <el-table-column type="selection"></el-table-column>
+            <el-table-column label="Equipment Name">
+              <template slot-scope="scope">{{ scope.row.equipments }}</template>
+            </el-table-column>
+          </el-table>
+        </el-collapse-item>
+
+        <el-collapse-item title="Stock" name="3">
+          <el-table ref="multipleStockTable" :data="stockTableData" style="width: 100%" @selection-change="handleSelectionChange">
+            <el-table-column type="selection"></el-table-column>
+            <el-table-column label="Equipment Name">
+              <template slot-scope="scope">{{ scope.row.equipments }}</template>
+            </el-table-column>
+          </el-table>
+        </el-collapse-item>
+
+      </el-collapse>
+      
+    </div>
+  </div>
+</template>
+
+<script>
+
+import { getAllCurrencies } from '@/api/equipment'
+
+export default {
+  data() {
+    return {
+      currencyTableData: [],
+      cryptoCurrencyTableData: [],
+      stockTableData: [],
+      multipleSelection: []
+    }
+  },
+  async created() {
+    this.currencyTableData = await this.getCurrency()
+  },
+  methods: {
+    async getCurrency() {
+      await this.$store.dispatch('equipment/getAllCurrencies').then(response =>{
+        var res = this.$store.getters.currencyResult
+        console.log("here")
+        console.log(res)
+      }).catch(error => {
+        console.log(error)
+      })
+      return 
+    }
+  }
+}
+</script>

--- a/frontend/TraderX/src/views/portfolio/index.vue
+++ b/frontend/TraderX/src/views/portfolio/index.vue
@@ -1,36 +1,56 @@
 <template>
   <div class="app-container">
     <div style="margin-top: 30px; margin-bottom: 50px; margin-left: 60px; margin-right: 60px">
-      <el-collapse v-model="activeNames">
+      <div style="text-align: center; padding-bottom: 30px; float:right">
+        <el-button @click="showDialog=true" type="primary"><svg-icon style="margin-right:10px" icon-class="documentation" />Add Trading Equipment To Portfolio</el-button>
+      </div>
 
-        <el-collapse-item title="Currency" name="1">
-          <el-table ref="multipleCurrencyTable" :data="currencyTableData" style="width: 100%" @selection-change="handleSelectionChange">
-            <el-table-column type="selection"></el-table-column>
-            <el-table-column label="Equipment Name">
-              <template slot-scope="scope">{{ scope.row.equipments }}</template>
-            </el-table-column>
-          </el-table>
-        </el-collapse-item>
+      <el-table ref="alreadyAddedTable" :data="alreadyAddedTableData" style="width: 100%">
+        <el-table-column label="Equipment Name">
+          <template slot-scope="scope">{{ scope.row.equipmentname }}</template>
+        </el-table-column>
+      </el-table>
 
-        <el-collapse-item title="Crypto-Currency" name="2">
-          <el-table ref="multipleCryptoCurrencyTable" :data="cryptoCurrencyTableData" style="width: 100%" @selection-change="handleSelectionChange">
-            <el-table-column type="selection"></el-table-column>
-            <el-table-column label="Equipment Name">
-              <template slot-scope="scope">{{ scope.row.equipments }}</template>
-            </el-table-column>
-          </el-table>
-        </el-collapse-item>
+      <el-dialog title="Select Trading Equipment" :visible.sync="showDialog">
+        <el-button @click="handleAddEquipmentPortfolio" type="primary" style="">
+          Add To Portfolio
+        </el-button>
+        
+        <p></p>
+        
+        <el-collapse v-model="activeNames">
 
-        <el-collapse-item title="Stock" name="3">
-          <el-table ref="multipleStockTable" :data="stockTableData" style="width: 100%" @selection-change="handleSelectionChange">
-            <el-table-column type="selection"></el-table-column>
-            <el-table-column label="Equipment Name">
-              <template slot-scope="scope">{{ scope.row.equipments }}</template>
-            </el-table-column>
-          </el-table>
-        </el-collapse-item>
+          <el-collapse-item title="Currency" name="1">
+            <el-table ref="multipleCurrencyTable" :data="currencyTableData" style="width: 100%" @selection-change="handleSelectionChange">
+              <el-table-column type="selection"></el-table-column>
+              <el-table-column label="Equipment Name">
+                <template slot-scope="scope">{{ scope.row.equipmentname }}</template>
+              </el-table-column>
+            </el-table>
+          </el-collapse-item>
 
-      </el-collapse>
+          <el-collapse-item title="Crypto-Currency" name="2">
+            <el-table ref="multipleCryptoCurrencyTable" :data="cryptoCurrencyTableData" style="width: 100%" @selection-change="handleSelectionChange">
+              <el-table-column type="selection"></el-table-column>
+              <el-table-column label="Equipment Name">
+                <template slot-scope="scope">{{ scope.row.equipmentname }}</template>
+              </el-table-column>
+            </el-table>
+          </el-collapse-item>
+
+          <el-collapse-item title="Stock" name="3">
+            <el-table ref="multipleStockTable" :data="stockTableData" style="width: 100%" @selection-change="handleSelectionChange">
+              <el-table-column type="selection"></el-table-column>
+              <el-table-column label="Equipment Name">
+                <template slot-scope="scope">{{ scope.row.equipmentname }}</template>
+              </el-table-column>
+            </el-table>
+          </el-collapse-item>
+
+        </el-collapse>
+      </el-dialog>
+
+      
       
     </div>
   </div>
@@ -39,6 +59,7 @@
 <script>
 
 import { getAllCurrencies, getAllCryptoCurrencies, getAllStocks } from '@/api/equipment'
+import equipment from '../../store/modules/equipment'
 
 export default {
   data() {
@@ -46,41 +67,86 @@ export default {
       currencyTableData: [],
       cryptoCurrencyTableData: [],
       stockTableData: [],
-      multipleSelection: []
+      alreadyAddedTableData: [],
+      multipleSelection: [],
+      activeNames: [],
+      showDialog: false,
     }
   },
   async created() {
-    this.currencyTableData = await this.getCurrency()
-    this.cryptoCurrencyTableData = await this.getCryptoCurrency()
-    this.stockTableData = await this.getStock()
+    await this.getCurrency()
+    await this.getCryptoCurrency()
+    await this.getStock()
   },
   methods: {
     async getCurrency() {
       await this.$store.dispatch('equipment/getAllCurrencies').then(response =>{
         var res = this.$store.getters.currencyResult
-        console.log(res)
+        var equip = []
+        for (var i = 0; i < res.equipments.length; i++) {
+          equip.push({
+            "equipmentname": res.equipments[i],
+            "base": res.base
+          })
+        }
+        this.currencyTableData = equip
       }).catch(error => {
         console.log(error)
       })
-      return 
     },
     async getCryptoCurrency() {
       await this.$store.dispatch('equipment/getAllCryptoCurrencies').then(response =>{
         var res = this.$store.getters.cryptoCurrencyResult
-        console.log(res)
+        var equip = []
+        for (var i = 0; i < res.equipments.length; i++) {
+          equip.push({
+            "equipmentname": res.equipments[i],
+            "base": res.base
+          })
+        }
+        this.cryptoCurrencyTableData = equip
       }).catch(error => {
         console.log(error)
       })
-      return 
     },
     async getStock() {
       await this.$store.dispatch('equipment/getAllStocks').then(response =>{
         var res = this.$store.getters.stockResult
-        console.log(res)
+        var equip = []
+        for (var i = 0; i < res.equipments.length; i++) {
+          equip.push({
+            "equipmentname": res.equipments[i],
+            "base": res.base
+          })
+        }
+        this.stockTableData = equip
       }).catch(error => {
         console.log(error)
       })
-      return 
+    },
+    toggleSelection(rows) {
+      if (rows) {
+        rows.forEach(row => {
+          this.$refs.multipleTable.toggleRowSelection(row);
+        });
+      } else {
+        this.$refs.multipleTable.clearSelection();
+      }
+    },
+    handleSelectionChange(val) {
+      this.multipleSelection = val;
+    },
+    handleAddEquipmentPortfolio(){
+      var currencySelections = this.$refs.multipleCurrencyTable.selection
+      var cryptoCurrencySelections = this.$refs.multipleCryptoCurrencyTable.selection
+      var stockSelectinos = this.$refs.multipleStockTable.selection
+      var selectedAll = currencySelections.concat(cryptoCurrencySelections).concat(stockSelectinos)
+      for(var i = 0; i < selectedAll.length; i++) {
+        console.log(selectedAll[i])
+        if(!this.alreadyAddedTableData.includes(selectedAll[i])){
+          this.alreadyAddedTableData.push(selectedAll[i])
+        }
+      }
     }
   }
 }

--- a/frontend/TraderX/src/views/portfolio/index.vue
+++ b/frontend/TraderX/src/views/portfolio/index.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="app-container">
     <div style="margin-top: 30px; margin-bottom: 50px; margin-left: 60px; margin-right: 60px">
-      <div style="text-align: center; padding-bottom: 30px; float:right">
+      <div style="float:left">
+        <font size=5>PORTFOLIO NAME : <b>{{ portfolioname }}</b></font>
+      </div>
+
+      <div style="padding-bottom: 30px; float:right">
         <el-button @click="showDialog=true" type="primary"><svg-icon style="margin-right:10px" icon-class="documentation" />Add Trading Equipment To Portfolio</el-button>
       </div>
 
@@ -48,9 +52,7 @@
           </el-collapse-item>
 
         </el-collapse>
-      </el-dialog>
-
-      
+      </el-dialog>   
       
     </div>
   </div>
@@ -71,9 +73,11 @@ export default {
       multipleSelection: [],
       activeNames: [],
       showDialog: false,
+      portfolioname : ""
     }
   },
   async created() {
+    this.portfolioname = this.$route.path.split('/')[2].toUpperCase()
     await this.getCurrency()
     await this.getCryptoCurrency()
     await this.getStock()
@@ -142,11 +146,15 @@ export default {
       var stockSelectinos = this.$refs.multipleStockTable.selection
       var selectedAll = currencySelections.concat(cryptoCurrencySelections).concat(stockSelectinos)
       for(var i = 0; i < selectedAll.length; i++) {
-        console.log(selectedAll[i])
         if(!this.alreadyAddedTableData.includes(selectedAll[i])){
           this.alreadyAddedTableData.push(selectedAll[i])
         }
       }
+      this.showDialog = false
+      this.$refs.multipleCurrencyTable.clearSelection();
+      this.$refs.multipleCryptoCurrencyTable.clearSelection();
+      this.$refs.multipleStockTable.clearSelection();
+      this.activeNames = []
     }
   }
 }

--- a/frontend/TraderX/src/views/profile/components/Events.vue
+++ b/frontend/TraderX/src/views/profile/components/Events.vue
@@ -1,9 +1,0 @@
-<template>
-  <div>
-    <p>Events will be added</p>
-  </div>
-</template>
-
-<script>
-
-</script>

--- a/frontend/TraderX/src/views/profile/components/Explore.vue
+++ b/frontend/TraderX/src/views/profile/components/Explore.vue
@@ -1,9 +1,0 @@
-<template>
-  <div>
-    <p>Explore will be added</p>
-  </div>
-</template>
-
-<script>
-
-</script>

--- a/frontend/TraderX/src/views/profile/components/News.vue
+++ b/frontend/TraderX/src/views/profile/components/News.vue
@@ -1,9 +1,0 @@
-<template>
-  <div>
-    <p>News will be added</p>
-  </div>
-</template>
-
-<script>
-
-</script>

--- a/frontend/TraderX/src/views/profile/components/Portfolio.vue
+++ b/frontend/TraderX/src/views/profile/components/Portfolio.vue
@@ -4,18 +4,15 @@
       <el-button @click="showDialog=true" type="primary"><svg-icon style="margin-right:10px" icon-class="documentation" />Create Portfolio</el-button>
     </div>
     <div>
-      <CoolCard :cardData="all_portfolios"/>
+      <CoolCard :cardData="all_portfolios" :username="username"/>
     </div>
     <el-dialog title="Create Portfolio" :visible.sync="showDialog">
       <el-form @submit.native.prevent="handleCreatePortfolio" ref="createPortfolioForm" :model="createPortfolioForm">
         <el-form-item prop="Portfolio Name">
           <el-input ref="portfolioName" placeholder="Portfolio Name" v-model="createPortfolioForm.portfolioName" />
         </el-form-item>
-        <el-form-item prop="Portfolio Description">
-          <el-input ref="portfolioDescription" placeholder="Portfolio Description" v-model="createPortfolioForm.portfolioDescription" />
-        </el-form-item>
-        <el-button @click="handleCreatePortfolio">
-          Submit
+        <el-button @click="handleCreatePortfolio" type="primary">
+          Create
         </el-button>
       </el-form>
     </el-dialog>
@@ -27,6 +24,9 @@
 import CoolCard from '@/components/CoolCard'
 
 export default {
+  props: {
+    username: String
+  },
   components: { CoolCard },
   data() {
     return {
@@ -40,12 +40,16 @@ export default {
   },
   methods: {
     handleCreatePortfolio(){
-      this.showDialog = false,
-      this.all_portfolios.push({
-        portfolioName : this.createPortfolioForm.portfolioName,
-        portfolioDescription: this.createPortfolioForm.portfolioDescription
-      })
-      this.$notify({ title: 'Success', message: 'Portfolio is posted', type: 'success', duration: 2000 })
+      if (this.createPortfolioForm.portfolioName == '') {
+        this.$message.error("Portfolio Name Can Not Be Empty")
+      } else {
+        this.showDialog = false,
+        this.all_portfolios.push({
+          portfolioName : this.createPortfolioForm.portfolioName,
+          portfolioDescription: this.createPortfolioForm.portfolioDescription
+        })
+        this.$notify({ title: 'Success', message: 'Portfolio is posted', type: 'success', duration: 2000 })
+      }
     }
   }
 }

--- a/frontend/TraderX/src/views/profile/components/UserCard.vue
+++ b/frontend/TraderX/src/views/profile/components/UserCard.vue
@@ -78,9 +78,6 @@ export default {
   },
   created() {
     var tempUser = this.user.username
-    console.log(this.user.username)
-    console.log(tempUser)
-    console.log(this.$store.getters.userInfo.username)
     this.isSelf = tempUser.username == this.$store.getters.userInfo.name ? true : false
     this.isFollowing = tempUser.followingStatus == 'FOLLOWING' ? true : false
     this.isNotFollowing = tempUser.followingStatus == 'NOT_FOLLOWING' ? true : false

--- a/frontend/TraderX/src/views/profile/index.vue
+++ b/frontend/TraderX/src/views/profile/index.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="app-container">
-    <github-corner class="github-corner" />
     <div v-if="user">
       <el-row :gutter="20">
         <el-col
@@ -48,11 +47,10 @@ import UserCard from './components/UserCard'
 import Portfolio from './components/Portfolio'
 import Articles from './components/Articles'
 import Editprofile from './components/Editprofile'
-import GithubCorner from '@/components/GithubCorner'
 
 export default {
   name: 'Profile',
-  components: { UserCard, Portfolio, Articles, Editprofile, GithubCorner },
+  components: { UserCard, Portfolio, Articles, Editprofile },
   data() {
     return {
       user: Object,

--- a/frontend/TraderX/src/views/profile/index.vue
+++ b/frontend/TraderX/src/views/profile/index.vue
@@ -20,25 +20,7 @@
                 label="Portfolio"
                 name="portfolio"
               >
-                <portfolio />
-              </el-tab-pane>
-              <el-tab-pane
-                label="Explore"
-                name="explore"
-              >
-                <explore />
-              </el-tab-pane>
-              <el-tab-pane
-                label="Event"
-                name="events"
-              >
-                <events />
-              </el-tab-pane>
-              <el-tab-pane
-                label="New"
-                name="news"
-              >
-                <news />
+                <portfolio :username="this.user.username"/>
               </el-tab-pane>
               <el-tab-pane
                 label="Article"
@@ -64,19 +46,16 @@
 import { mapGetters } from 'vuex'
 import UserCard from './components/UserCard'
 import Portfolio from './components/Portfolio'
-import Explore from './components/Explore'
-import Events from './components/Events'
-import News from './components/News'
 import Articles from './components/Articles'
 import Editprofile from './components/Editprofile'
 import GithubCorner from '@/components/GithubCorner'
 
 export default {
   name: 'Profile',
-  components: { UserCard, Portfolio, Explore, Events, News, Articles, Editprofile, GithubCorner },
+  components: { UserCard, Portfolio, Articles, Editprofile, GithubCorner },
   data() {
     return {
-      user: this.$store.getters.userInfo,
+      user: Object,
       activeTab: 'portfolio'
     }
   },
@@ -87,9 +66,18 @@ export default {
       'roles'
     ])
   },
-  created() {   
+  async created() {
+    await this.getUserInfo()
   },
   methods: {
+    async getUserInfo() {
+      await this.$store.dispatch('user/getInfo').then(response =>{
+        this.user = this.$store.getters.userInfo
+      }).catch(error => {
+        console.log(error)
+      })
+    },
+      
   },
   mounted() {
   }

--- a/frontend/TraderX/src/views/user-profile/index.vue
+++ b/frontend/TraderX/src/views/user-profile/index.vue
@@ -22,18 +22,6 @@
                 <portfolio />
               </el-tab-pane>
               <el-tab-pane
-                label="Event"
-                name="events"
-              >
-                <events />
-              </el-tab-pane>
-              <el-tab-pane
-                label="New"
-                name="news"
-              >
-                <news />
-              </el-tab-pane>
-              <el-tab-pane
                 label="Article"
                 name="articles"
               >
@@ -52,14 +40,12 @@
 import { mapGetters } from 'vuex'
 import UserCard from '@/views/profile/components/UserCard'
 import Portfolio from '@/views/profile/components/Portfolio'
-import Events from '@/views/profile/components/Events'
-import News from '@/views/profile/components/News'
 import Articles from '@/views/profile/components/Articles'
 import { getUser } from '@/api/user'
 
 export default {
   name: 'UserProfile',
-  components: { UserCard, Portfolio, Events, News, Articles },
+  components: { UserCard, Portfolio, Articles },
   data() {
     return {
       user: {},


### PR DESCRIPTION
I implemented the portfolio page. Before implementing this page, we were able to create a portfolio card with a name and description. After discussing with backend team, I deleted description field. When the user clicks to the portfolio card, we redirect him/her to a new page. All functionalities are implemented in only frontend. We don't have necessary endpoints currently, after having necessary endpoints, I will connect frontend with backend. Also, we can not show all fields for a trading equipment for now. One can follow the issue #191 for updates.

The page looks like below now:

![Screen Shot 2019-11-22 at 00 03 37](https://user-images.githubusercontent.com/16756389/69376608-9d8e7c80-0cbb-11ea-8778-12e82102f76b.png)

![Screen Shot 2019-11-22 at 00 04 01](https://user-images.githubusercontent.com/16756389/69376618-a7b07b00-0cbb-11ea-933b-c3c79ae62e9c.png)
