### PR TITLE
[Frontend] Created detailed page for every trading equipment

### DIFF
--- a/frontend/TraderX/src/views/trading-equipment/components/LineChartComparison.vue
+++ b/frontend/TraderX/src/views/trading-equipment/components/LineChartComparison.vue
@@ -63,16 +63,16 @@ export default {
       this.chart = echarts.init(this.$el, 'macarons')
       this.setOptions(this.chartData)
     },
-    setOptions({moneyCurrencies}) {
+    setOptions({equipmentData}) {
       var legendData = []
       var seriesData = []
-      moneyCurrencies.forEach(function(currency) {
-          legendData.push(currency.label)
+      equipmentData.forEach(function(equipment) {
+          legendData.push(equipment.label)
           seriesData.push({
-            name: currency.label,
+            name: equipment.label,
             smooth: true,
             type: 'line',
-            data: currency.data.open.slice(open.length-21, open.length-1),
+            data: equipment.data.open.slice(open.length-21, open.length-1),
             animationDuration: 2800,
             animationEasing: 'cubicInOut'
           })

--- a/frontend/TraderX/src/views/trading-equipment/components/LineChartComparison.vue
+++ b/frontend/TraderX/src/views/trading-equipment/components/LineChartComparison.vue
@@ -67,7 +67,6 @@ export default {
       var legendData = []
       var seriesData = []
       moneyCurrencies.forEach(function(currency) {
-          console.log(currency)
           legendData.push(currency.label)
           seriesData.push({
             name: currency.label,

--- a/frontend/TraderX/src/views/trading-equipment/cryptocurrencies.vue
+++ b/frontend/TraderX/src/views/trading-equipment/cryptocurrencies.vue
@@ -1,0 +1,232 @@
+<template>
+ 
+  <div>
+    <el-row style="background:#fff;padding:16px 16px 0;margin-bottom:32px;">
+      <el-card class='raddar-chart-container'>
+        <raddar-chart :chart-data="chartData"/>
+      </el-card>
+    </el-row>
+
+    <el-row style="background:#fff;padding:16px 16px 0;margin-bottom:32px;">
+      <el-card class='raddar-chart-container'>
+        <p class="te-info-text">Last 20 days' opening values of every currency is as follows:</p>
+        <line-chart-comparison :chart-data="comparisonData"/>
+      </el-card>
+    </el-row>
+
+    <el-row :gutter="20" style="padding:16px 16px 0;margin-bottom:32px;">
+      <el-card>
+        <el-tabs v-model="activeTab">
+          <el-tab-pane class='te-tab-pane' v-for="mc in moneyCurrencies" :key="mc.key" :label="mc.label" :name="mc.key" :type="mc.key">
+              <div v-if="activeTab==mc.key">
+                <p class="te-info-text">Last 100 days' American Dollar / {{ mc.label }} with openning values is as follows:</p>
+                <div class='chart-wrapper'>
+                  <line-chart :type="mc.key" :chart-data="mc.data"/>
+                </div>
+
+                <p class="te-info-text">Last 20 days' American Dollar / {{ mc.label }} with openning, closing, highest and lowest values is as follows:</p>
+                <div class='chart-wrapper'>
+                  <line-chart-detailed :type="mc.key" :chart-data="mc.data"/>
+                </div>
+
+                <el-button class='change-base-button' @click="changeBaseofEquipment(mc.label)"><svg-icon style="margin-right:10px" icon-class="chart" />Change the Base</el-button>
+                <el-button class='buy-button' @click="buyEquipment"><svg-icon style="margin-right:10px" icon-class="shopping" />Buy Equipment</el-button>
+              </div>
+          </el-tab-pane>
+        </el-tabs>
+      </el-card>
+    </el-row>
+  </div>
+   
+</template>
+
+<script>
+import LineChart from './components/LineChart'
+import LineChartDetailed from './components/LineChartDetailed'
+import LineChartComparison from './components/LineChartComparison'
+import RaddarChart from './components/RaddarChart'
+
+// The usual sorting in javascript sorts alphabetically which causes mistake in our code
+const numberSort = function (a,b) {
+    return a - b;
+};
+
+export default {
+  name: 'DashboardAdmin',
+  components: {
+    LineChartComparison,
+    LineChartDetailed,
+    LineChart,
+    RaddarChart,
+  },
+  data() {
+    return {
+      chartData: {},
+      // moneyCurrencies is expected to be: 
+      // [
+      //   {
+      //     label: Euro,
+      //     key: EUR,
+      //     data: {
+      //       open: [...],
+      //       close: [...],
+      //       high: [...],
+      //       low: [...],
+      //       current: [...] 
+      //     }
+      //   }, 
+      //   {
+      //     label: Japanese Yen,
+      //     key: JPY
+      //   }, ...
+      // ]
+      moneyCurrencies: [],
+      comparisonData: {moneyCurrencies: []},
+      activeTab: 'JPY'
+    }
+  },
+  async created() {
+    var equipmentList = await this.getEquipmentList()
+    // Fill the moneyCurrencies with equipment list
+    equipmentList.forEach(function(equipmentKey) {
+      this.moneyCurrencies.push({key: equipmentKey})
+    }, this)
+    var equipmentValues = await this.getEquipmentValues(equipmentList) 
+    this.createRadarChartData(equipmentValues)
+    this.moneyCurrencies = equipmentValues
+    
+    this.comparisonData.moneyCurrencies = this.moneyCurrencies
+  },
+  methods: {
+    // Promise for getting equipments list 
+    async getEquipmentList() {
+      try {
+        await this.$store.dispatch('equipment/getAllCryptoCurrencies')
+        var res = this.$store.getters.cryptoCurrencyResult
+        return res.equipments
+      } catch (error) {
+        console.log(error)
+        return error
+      }  
+    },
+
+    // equipment = ['JPY', 'TRY', ...]
+    async getEquipmentValues(equipmentList) {
+      // equipmentValues = [{label="Turkish Lira", key="TRY", data={open=[5.6, 4.34, 7.54,...], close=[..], high=[..], low=[..]}}, {label="Japanese Yen", key="JPY", data={actualData=[12.2312, 11.234545, 10.23234, ...]}} ...]
+      var equipmentValues = []
+      
+      equipmentList.forEach(async function(e) {
+        try {
+          await this.$store.dispatch('equipment/getEquipment', e.toLowerCase())
+          var res = this.$store.getters.equipmentQueryResult
+          equipmentValues.push({})
+          equipmentValues[equipmentValues.length-1].key = res.equipment.code
+          equipmentValues[equipmentValues.length-1].label = res.equipment.name
+          equipmentValues[equipmentValues.length-1].currentValue = res.equipment.currentValue
+          equipmentValues[equipmentValues.length-1].data = {
+            open: [],
+            close: [],
+            high: [],
+            low: [],
+            current: [],
+          }
+          res.historicalValues.forEach(function(val) {
+            equipmentValues[equipmentValues.length-1].data.open.push(val.open)
+            equipmentValues[equipmentValues.length-1].data.close.push(val.close)
+            equipmentValues[equipmentValues.length-1].data.high.push(val.high)
+            equipmentValues[equipmentValues.length-1].data.low.push(val.low)
+            equipmentValues[equipmentValues.length-1].data.current.push(res.equipment.currentValue)
+          })
+        } catch (error) {
+          console.log(error)
+        }
+      }, this)
+      return equipmentValues
+    },
+
+    // Put values from 1 to 3 to each of equipment in categories: Stability, Growth Rate, Values
+    createRadarChartData(equipmentValues) {
+      // wait for data to be pulled properly
+      if (equipmentValues.length == 0) {
+        setTimeout(() => {
+          this.createRadarChartData(equipmentValues)
+        }, 500)
+      } else {
+        this.activeTab = equipmentValues[0].key
+        var stabilities = [] // calculate stability of each trading equipment
+        var growth = [] // calculate growth rate for each equipment
+        var values = []
+        var legendData = [] // For getting legendData
+        var graphData = []
+
+        const equipmentSize = equipmentValues.length
+        for (let i = 0; i < equipmentSize; i++) {
+          let valueAverage = 0
+          equipmentValues[i].data.open.forEach(function(val) {
+            valueAverage += val / equipmentValues[i].data.open.length
+          })
+          let stability = Math.abs(valueAverage - equipmentValues[i].data.open[0]) / equipmentValues[i].data.open.length
+          let growthRate = 0
+          for (let j = 0; j < equipmentValues[i].data.open.length-1; j++) {
+            stability += Math.abs(valueAverage - equipmentValues[i].data.open[j+1]) / equipmentValues[i].data.open.length
+            growthRate += (1/equipmentValues[i].data.open[j] - 1/equipmentValues[i].data.open[j+1]) / equipmentValues[i].data.open.length
+          }
+          stabilities.push(stability)
+          growth.push(growthRate)
+          values.push(1/equipmentValues[i].currentValue)
+          legendData.push(equipmentValues[i].label)
+          graphData.push({value: [stability, growthRate, 1/equipmentValues[i].currentValue], name: equipmentValues[i].label})
+        }
+        stabilities.sort(numberSort)
+        growth.sort(numberSort)
+        values.sort(numberSort)
+        for (let i = 0; i < equipmentSize; i++) {
+          graphData[i].value = [stabilities.indexOf(graphData[i].value[0])+1, growth.indexOf(graphData[i].value[1])+1, values.indexOf(graphData[i].value[2])+1]
+        }
+        var indicatorData = [
+          { name: 'Stability', max: equipmentSize+0.5 },
+          { name: 'Growth', max: equipmentSize+0.5 },
+          { name: 'Value', max: equipmentSize+0.5 }
+        ]
+        this.chartData = {
+          legendData: legendData,
+          graphData: graphData,
+          indicatorData: indicatorData
+        }
+      }
+     
+    },
+
+    buyEquipment() {
+      this.$notify({
+        title: 'Success',
+        message: 'Equipment Bought',
+        type: 'success',
+        duration: 2000
+      })
+    },
+
+    changeBaseofEquipment(equipmentLabel) {
+      this.moneyCurrencies.forEach(function(currency) {
+        if (currency.label == equipmentLabel) {
+          for (let i = 0; i < currency.data.open.length; i++) {
+            currency.data.open[i] = 1/currency.data.open[i]
+            currency.data.close[i] = 1/currency.data.close[i]
+            currency.data.low[i] = 1/currency.data.low[i]
+            currency.data.high[i] = 1/currency.data.high[i]
+            currency.data.current[i] = 1/currency.data.current[i]
+          }
+        }
+      }, this)
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+
+.raddar-chart-container {
+    margin-top: 10;
+}
+
+</style>

--- a/frontend/TraderX/src/views/trading-equipment/cryptocurrencies.vue
+++ b/frontend/TraderX/src/views/trading-equipment/cryptocurrencies.vue
@@ -110,9 +110,7 @@ export default {
       }  
     },
 
-    // equipment = ['JPY', 'TRY', ...]
     async getEquipmentValues(equipmentList) {
-      // equipmentValues = [{label="Turkish Lira", key="TRY", data={open=[5.6, 4.34, 7.54,...], close=[..], high=[..], low=[..]}}, {label="Japanese Yen", key="JPY", data={actualData=[12.2312, 11.234545, 10.23234, ...]}} ...]
       var equipmentValues = []
       
       equipmentList.forEach(async function(e) {

--- a/frontend/TraderX/src/views/trading-equipment/cryptocurrencies.vue
+++ b/frontend/TraderX/src/views/trading-equipment/cryptocurrencies.vue
@@ -17,19 +17,19 @@
     <el-row :gutter="20" style="padding:16px 16px 0;margin-bottom:32px;">
       <el-card>
         <el-tabs v-model="activeTab">
-          <el-tab-pane class='te-tab-pane' v-for="mc in moneyCurrencies" :key="mc.key" :label="mc.label" :name="mc.key" :type="mc.key">
-              <div v-if="activeTab==mc.key">
-                <p class="te-info-text">Last 100 days' American Dollar / {{ mc.label }} with openning values is as follows:</p>
+          <el-tab-pane class='te-tab-pane' v-for="ed in equipmentData" :key="ed.key" :label="ed.label" :name="ed.key" :type="ed.key">
+              <div v-if="activeTab==ed.key">
+                <p class="te-info-text">Last 100 days' American Dollar / {{ ed.label }} with openning values is as follows:</p>
                 <div class='chart-wrapper'>
-                  <line-chart :type="mc.key" :chart-data="mc.data"/>
+                  <line-chart :type="ed.key" :chart-data="ed.data"/>
                 </div>
 
-                <p class="te-info-text">Last 20 days' American Dollar / {{ mc.label }} with openning, closing, highest and lowest values is as follows:</p>
+                <p class="te-info-text">Last 20 days' American Dollar / {{ ed.label }} with openning, closing, highest and lowest values is as follows:</p>
                 <div class='chart-wrapper'>
-                  <line-chart-detailed :type="mc.key" :chart-data="mc.data"/>
+                  <line-chart-detailed :type="ed.key" :chart-data="ed.data"/>
                 </div>
 
-                <el-button class='change-base-button' @click="changeBaseofEquipment(mc.label)"><svg-icon style="margin-right:10px" icon-class="chart" />Change the Base</el-button>
+                <el-button class='change-base-button' @click="changeBaseofEquipment(ed.label)"><svg-icon style="margin-right:10px" icon-class="chart" />Change the Base</el-button>
                 <el-button class='buy-button' @click="buyEquipment"><svg-icon style="margin-right:10px" icon-class="shopping" />Buy Equipment</el-button>
               </div>
           </el-tab-pane>
@@ -62,40 +62,22 @@ export default {
   data() {
     return {
       chartData: {},
-      // moneyCurrencies is expected to be: 
-      // [
-      //   {
-      //     label: Euro,
-      //     key: EUR,
-      //     data: {
-      //       open: [...],
-      //       close: [...],
-      //       high: [...],
-      //       low: [...],
-      //       current: [...] 
-      //     }
-      //   }, 
-      //   {
-      //     label: Japanese Yen,
-      //     key: JPY
-      //   }, ...
-      // ]
-      moneyCurrencies: [],
-      comparisonData: {moneyCurrencies: []},
+      equipmentData: [],
+      comparisonData: {equipmentData: []},
       activeTab: 'JPY'
     }
   },
   async created() {
     var equipmentList = await this.getEquipmentList()
-    // Fill the moneyCurrencies with equipment list
+    // Fill the equipmentData with equipment list
     equipmentList.forEach(function(equipmentKey) {
-      this.moneyCurrencies.push({key: equipmentKey})
+      this.equipmentData.push({key: equipmentKey})
     }, this)
     var equipmentValues = await this.getEquipmentValues(equipmentList) 
     this.createRadarChartData(equipmentValues)
-    this.moneyCurrencies = equipmentValues
+    this.equipmentData = equipmentValues
     
-    this.comparisonData.moneyCurrencies = this.moneyCurrencies
+    this.comparisonData.equipmentData = this.equipmentData
   },
   methods: {
     // Promise for getting equipments list 
@@ -205,7 +187,7 @@ export default {
     },
 
     changeBaseofEquipment(equipmentLabel) {
-      this.moneyCurrencies.forEach(function(currency) {
+      this.equipmentData.forEach(function(currency) {
         if (currency.label == equipmentLabel) {
           for (let i = 0; i < currency.data.open.length; i++) {
             currency.data.open[i] = 1/currency.data.open[i]

--- a/frontend/TraderX/src/views/trading-equipment/money_currencies.vue
+++ b/frontend/TraderX/src/views/trading-equipment/money_currencies.vue
@@ -209,7 +209,6 @@ export default {
     changeBaseofEquipment(equipmentLabel) {
       this.equipmentData.forEach(function(currency) {
         if (currency.label == equipmentLabel) {
-          console.log(currency)
           for (let i = 0; i < currency.data.open.length; i++) {
             currency.data.open[i] = 1/currency.data.open[i]
             currency.data.close[i] = 1/currency.data.close[i]

--- a/frontend/TraderX/src/views/trading-equipment/money_currencies.vue
+++ b/frontend/TraderX/src/views/trading-equipment/money_currencies.vue
@@ -101,8 +101,8 @@ export default {
     // Promise for getting equipments list 
     async getEquipmentList() {
       try {
-        await this.$store.dispatch('equipment/listEquipment', 'currency')
-        var res = this.$store.getters.equipmentQueryResult
+        await this.$store.dispatch('equipment/getAllCurrencies')
+        var res = this.$store.getters.currencyResult
         return res.equipments
       } catch (error) {
         console.log(error)

--- a/frontend/TraderX/src/views/trading-equipment/money_currencies.vue
+++ b/frontend/TraderX/src/views/trading-equipment/money_currencies.vue
@@ -17,19 +17,19 @@
     <el-row :gutter="20" style="padding:16px 16px 0;margin-bottom:32px;">
       <el-card>
         <el-tabs v-model="activeTab">
-          <el-tab-pane class='te-tab-pane' v-for="mc in moneyCurrencies" :key="mc.key" :label="mc.label" :name="mc.key" :type="mc.key">
-              <div v-if="activeTab==mc.key">
-                <p class="te-info-text">Last 100 days' American Dollar / {{ mc.label }} with openning values is as follows:</p>
+          <el-tab-pane class='te-tab-pane' v-for="ed in equipmentData" :key="ed.key" :label="ed.label" :name="ed.key" :type="ed.key">
+              <div v-if="activeTab==ed.key">
+                <p class="te-info-text">Last 100 days' American Dollar / {{ ed.label }} with openning values is as follows:</p>
                 <div class='chart-wrapper'>
-                  <line-chart :type="mc.key" :chart-data="mc.data"/>
+                  <line-chart :type="ed.key" :chart-data="ed.data"/>
                 </div>
 
-                <p class="te-info-text">Last 20 days' American Dollar / {{ mc.label }} with openning, closing, highest and lowest values is as follows:</p>
+                <p class="te-info-text">Last 20 days' American Dollar / {{ ed.label }} with openning, closing, highest and lowest values is as follows:</p>
                 <div class='chart-wrapper'>
-                  <line-chart-detailed :type="mc.key" :chart-data="mc.data"/>
+                  <line-chart-detailed :type="ed.key" :chart-data="ed.data"/>
                 </div>
 
-                <el-button class='change-base-button' @click="changeBaseofEquipment(mc.label)"><svg-icon style="margin-right:10px" icon-class="chart" />Change the Base</el-button>
+                <el-button class='change-base-button' @click="changeBaseofEquipment(ed.label)"><svg-icon style="margin-right:10px" icon-class="chart" />Change the Base</el-button>
                 <el-button class='buy-button' @click="buyEquipment"><svg-icon style="margin-right:10px" icon-class="shopping" />Buy Equipment</el-button>
               </div>
           </el-tab-pane>
@@ -62,7 +62,7 @@ export default {
   data() {
     return {
       chartData: {},
-      // moneyCurrencies is expected to be: 
+      // equipmentData is expected to be: 
       // [
       //   {
       //     label: Euro,
@@ -80,22 +80,22 @@ export default {
       //     key: JPY
       //   }, ...
       // ]
-      moneyCurrencies: [],
-      comparisonData: {moneyCurrencies: []},
+      equipmentData: [],
+      comparisonData: {equipmentData: []},
       activeTab: 'JPY'
     }
   },
   async created() {
     var equipmentList = await this.getEquipmentList()
-    // Fill the moneyCurrencies with equipment list
+    // Fill the equipmentData with equipment list
     equipmentList.forEach(function(equipmentKey) {
-      this.moneyCurrencies.push({key: equipmentKey})
+      this.equipmentData.push({key: equipmentKey})
     }, this)
     var equipmentValues = await this.getEquipmentValues(equipmentList) 
     this.createRadarChartData(equipmentValues)
-    this.moneyCurrencies = equipmentValues
+    this.equipmentData = equipmentValues
     
-    this.comparisonData.moneyCurrencies = this.moneyCurrencies
+    this.comparisonData.equipmentData = this.equipmentData
   },
   methods: {
     // Promise for getting equipments list 
@@ -207,7 +207,7 @@ export default {
     },
 
     changeBaseofEquipment(equipmentLabel) {
-      this.moneyCurrencies.forEach(function(currency) {
+      this.equipmentData.forEach(function(currency) {
         if (currency.label == equipmentLabel) {
           console.log(currency)
           for (let i = 0; i < currency.data.open.length; i++) {

--- a/frontend/TraderX/src/views/trading-equipment/stocks.vue
+++ b/frontend/TraderX/src/views/trading-equipment/stocks.vue
@@ -1,0 +1,233 @@
+<template>
+ 
+  <div>
+    <el-row style="background:#fff;padding:16px 16px 0;margin-bottom:32px;">
+      <el-card class='raddar-chart-container'>
+        <raddar-chart :chart-data="chartData"/>
+      </el-card>
+    </el-row>
+
+    <el-row style="background:#fff;padding:16px 16px 0;margin-bottom:32px;">
+      <el-card class='raddar-chart-container'>
+        <p class="te-info-text">Last 20 days' opening values of every currency is as follows:</p>
+        <line-chart-comparison :chart-data="comparisonData"/>
+      </el-card>
+    </el-row>
+
+    <el-row :gutter="20" style="padding:16px 16px 0;margin-bottom:32px;">
+      <el-card>
+        <el-tabs v-model="activeTab">
+          <el-tab-pane class='te-tab-pane' v-for="mc in moneyCurrencies" :key="mc.key" :label="mc.label" :name="mc.key" :type="mc.key">
+              <div v-if="activeTab==mc.key">
+                <p class="te-info-text">Last 100 days' American Dollar / {{ mc.label }} with openning values is as follows:</p>
+                <div class='chart-wrapper'>
+                  <line-chart :type="mc.key" :chart-data="mc.data"/>
+                </div>
+
+                <p class="te-info-text">Last 20 days' American Dollar / {{ mc.label }} with openning, closing, highest and lowest values is as follows:</p>
+                <div class='chart-wrapper'>
+                  <line-chart-detailed :type="mc.key" :chart-data="mc.data"/>
+                </div>
+
+                <el-button class='change-base-button' @click="changeBaseofEquipment(mc.label)"><svg-icon style="margin-right:10px" icon-class="chart" />Change the Base</el-button>
+                <el-button class='buy-button' @click="buyEquipment"><svg-icon style="margin-right:10px" icon-class="shopping" />Buy Equipment</el-button>
+              </div>
+          </el-tab-pane>
+        </el-tabs>
+      </el-card>
+    </el-row>
+  </div>
+   
+</template>
+
+<script>
+import LineChart from './components/LineChart'
+import LineChartDetailed from './components/LineChartDetailed'
+import LineChartComparison from './components/LineChartComparison'
+import RaddarChart from './components/RaddarChart'
+
+// The usual sorting in javascript sorts alphabetically which causes mistake in our code
+const numberSort = function (a,b) {
+    return a - b;
+};
+
+export default {
+  name: 'DashboardAdmin',
+  components: {
+    LineChartComparison,
+    LineChartDetailed,
+    LineChart,
+    RaddarChart,
+  },
+  data() {
+    return {
+      chartData: {},
+      // moneyCurrencies is expected to be: 
+      // [
+      //   {
+      //     label: Euro,
+      //     key: EUR,
+      //     data: {
+      //       open: [...],
+      //       close: [...],
+      //       high: [...],
+      //       low: [...],
+      //       current: [...] 
+      //     }
+      //   }, 
+      //   {
+      //     label: Japanese Yen,
+      //     key: JPY
+      //   }, ...
+      // ]
+      moneyCurrencies: [],
+      comparisonData: {moneyCurrencies: []},
+      activeTab: 'JPY'
+    }
+  },
+  async created() {
+    var equipmentList = await this.getEquipmentList()
+    // Fill the moneyCurrencies with equipment list
+    equipmentList.forEach(function(equipmentKey) {
+      this.moneyCurrencies.push({key: equipmentKey})
+    }, this)
+    var equipmentValues = await this.getEquipmentValues(equipmentList) 
+    this.createRadarChartData(equipmentValues)
+    this.moneyCurrencies = equipmentValues
+    
+    this.comparisonData.moneyCurrencies = this.moneyCurrencies
+  },
+  methods: {
+    // Promise for getting equipments list 
+    async getEquipmentList() {
+      try {
+        await this.$store.dispatch('equipment/getAllStocks')
+        var res = this.$store.getters.stockResult
+        return res.equipments
+      } catch (error) {
+        console.log(error)
+        return error
+      }  
+    },
+
+    // equipment = ['JPY', 'TRY', ...]
+    async getEquipmentValues(equipmentList) {
+      // equipmentValues = [{label="Turkish Lira", key="TRY", data={open=[5.6, 4.34, 7.54,...], close=[..], high=[..], low=[..]}}, {label="Japanese Yen", key="JPY", data={actualData=[12.2312, 11.234545, 10.23234, ...]}} ...]
+      var equipmentValues = []
+      
+      equipmentList.forEach(async function(e) {
+        try {
+          await this.$store.dispatch('equipment/getEquipment', e.toLowerCase())
+          var res = this.$store.getters.equipmentQueryResult
+          equipmentValues.push({})
+          equipmentValues[equipmentValues.length-1].key = res.equipment.code
+          equipmentValues[equipmentValues.length-1].label = res.equipment.name
+          equipmentValues[equipmentValues.length-1].currentValue = res.equipment.currentValue
+          equipmentValues[equipmentValues.length-1].data = {
+            open: [],
+            close: [],
+            high: [],
+            low: [],
+            current: [],
+          }
+          res.historicalValues.forEach(function(val) {
+            equipmentValues[equipmentValues.length-1].data.open.push(val.open)
+            equipmentValues[equipmentValues.length-1].data.close.push(val.close)
+            equipmentValues[equipmentValues.length-1].data.high.push(val.high)
+            equipmentValues[equipmentValues.length-1].data.low.push(val.low)
+            equipmentValues[equipmentValues.length-1].data.current.push(res.equipment.currentValue)
+          })
+        } catch (error) {
+          console.log(error)
+        }
+      }, this)
+      return equipmentValues
+    },
+
+    // Put values from 1 to 3 to each of equipment in categories: Stability, Growth Rate, Values
+    createRadarChartData(equipmentValues) {
+      // wait for data to be pulled properly
+      if (equipmentValues.length == 0) {
+        setTimeout(() => {
+          this.createRadarChartData(equipmentValues)
+        }, 500)
+      } else {
+        this.activeTab = equipmentValues[0].key
+        var stabilities = [] // calculate stability of each trading equipment
+        var growth = [] // calculate growth rate for each equipment
+        var values = []
+        var legendData = [] // For getting legendData
+        var graphData = []
+
+        const equipmentSize = equipmentValues.length
+        for (let i = 0; i < equipmentSize; i++) {
+          let valueAverage = 0
+          equipmentValues[i].data.open.forEach(function(val) {
+            valueAverage += val / equipmentValues[i].data.open.length
+          })
+          let stability = Math.abs(valueAverage - equipmentValues[i].data.open[0]) / equipmentValues[i].data.open.length
+          let growthRate = 0
+          for (let j = 0; j < equipmentValues[i].data.open.length-1; j++) {
+            stability += Math.abs(valueAverage - equipmentValues[i].data.open[j+1]) / equipmentValues[i].data.open.length
+            growthRate += (1/equipmentValues[i].data.open[j] - 1/equipmentValues[i].data.open[j+1]) / equipmentValues[i].data.open.length
+          }
+          stabilities.push(stability)
+          growth.push(growthRate)
+          values.push(1/equipmentValues[i].currentValue)
+          legendData.push(equipmentValues[i].label)
+          graphData.push({value: [stability, growthRate, 1/equipmentValues[i].currentValue], name: equipmentValues[i].label})
+        }
+        stabilities.sort(numberSort)
+        growth.sort(numberSort)
+        values.sort(numberSort)
+        for (let i = 0; i < equipmentSize; i++) {
+          graphData[i].value = [stabilities.indexOf(graphData[i].value[0])+1, growth.indexOf(graphData[i].value[1])+1, values.indexOf(graphData[i].value[2])+1]
+        }
+        var indicatorData = [
+          { name: 'Stability', max: equipmentSize+0.5 },
+          { name: 'Growth', max: equipmentSize+0.5 },
+          { name: 'Value', max: equipmentSize+0.5 }
+        ]
+        this.chartData = {
+          legendData: legendData,
+          graphData: graphData,
+          indicatorData: indicatorData
+        }
+      }
+     
+    },
+
+    buyEquipment() {
+      this.$notify({
+        title: 'Success',
+        message: 'Equipment Bought',
+        type: 'success',
+        duration: 2000
+      })
+    },
+
+    changeBaseofEquipment(equipmentLabel) {
+      this.moneyCurrencies.forEach(function(currency) {
+        if (currency.label == equipmentLabel) {
+          console.log(currency)
+          for (let i = 0; i < currency.data.open.length; i++) {
+            currency.data.open[i] = 1/currency.data.open[i]
+            currency.data.close[i] = 1/currency.data.close[i]
+            currency.data.low[i] = 1/currency.data.low[i]
+            currency.data.high[i] = 1/currency.data.high[i]
+            currency.data.current[i] = 1/currency.data.current[i]
+          }
+        }
+      }, this)
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+
+.raddar-chart-container {
+    margin-top: 10;
+}
+
+</style>

--- a/frontend/TraderX/src/views/trading-equipment/stocks.vue
+++ b/frontend/TraderX/src/views/trading-equipment/stocks.vue
@@ -110,9 +110,7 @@ export default {
       }  
     },
 
-    // equipment = ['JPY', 'TRY', ...]
     async getEquipmentValues(equipmentList) {
-      // equipmentValues = [{label="Turkish Lira", key="TRY", data={open=[5.6, 4.34, 7.54,...], close=[..], high=[..], low=[..]}}, {label="Japanese Yen", key="JPY", data={actualData=[12.2312, 11.234545, 10.23234, ...]}} ...]
       var equipmentValues = []
       
       equipmentList.forEach(async function(e) {

--- a/frontend/TraderX/src/views/trading-equipment/stocks.vue
+++ b/frontend/TraderX/src/views/trading-equipment/stocks.vue
@@ -189,7 +189,6 @@ export default {
     changeBaseofEquipment(equipmentLabel) {
       this.equipmentData.forEach(function(currency) {
         if (currency.label == equipmentLabel) {
-          console.log(currency)
           for (let i = 0; i < currency.data.open.length; i++) {
             currency.data.open[i] = 1/currency.data.open[i]
             currency.data.close[i] = 1/currency.data.close[i]

--- a/frontend/TraderX/src/views/trading-equipment/stocks.vue
+++ b/frontend/TraderX/src/views/trading-equipment/stocks.vue
@@ -17,19 +17,19 @@
     <el-row :gutter="20" style="padding:16px 16px 0;margin-bottom:32px;">
       <el-card>
         <el-tabs v-model="activeTab">
-          <el-tab-pane class='te-tab-pane' v-for="mc in moneyCurrencies" :key="mc.key" :label="mc.label" :name="mc.key" :type="mc.key">
-              <div v-if="activeTab==mc.key">
-                <p class="te-info-text">Last 100 days' American Dollar / {{ mc.label }} with openning values is as follows:</p>
+          <el-tab-pane class='te-tab-pane' v-for="ed in equipmentData" :key="ed.key" :label="ed.label" :name="ed.key" :type="ed.key">
+              <div v-if="activeTab==ed.key">
+                <p class="te-info-text">Last 100 days' American Dollar / {{ ed.label }} with openning values is as follows:</p>
                 <div class='chart-wrapper'>
-                  <line-chart :type="mc.key" :chart-data="mc.data"/>
+                  <line-chart :type="ed.key" :chart-data="ed.data"/>
                 </div>
 
-                <p class="te-info-text">Last 20 days' American Dollar / {{ mc.label }} with openning, closing, highest and lowest values is as follows:</p>
+                <p class="te-info-text">Last 20 days' American Dollar / {{ ed.label }} with openning, closing, highest and lowest values is as follows:</p>
                 <div class='chart-wrapper'>
-                  <line-chart-detailed :type="mc.key" :chart-data="mc.data"/>
+                  <line-chart-detailed :type="ed.key" :chart-data="ed.data"/>
                 </div>
 
-                <el-button class='change-base-button' @click="changeBaseofEquipment(mc.label)"><svg-icon style="margin-right:10px" icon-class="chart" />Change the Base</el-button>
+                <el-button class='change-base-button' @click="changeBaseofEquipment(ed.label)"><svg-icon style="margin-right:10px" icon-class="chart" />Change the Base</el-button>
                 <el-button class='buy-button' @click="buyEquipment"><svg-icon style="margin-right:10px" icon-class="shopping" />Buy Equipment</el-button>
               </div>
           </el-tab-pane>
@@ -62,40 +62,22 @@ export default {
   data() {
     return {
       chartData: {},
-      // moneyCurrencies is expected to be: 
-      // [
-      //   {
-      //     label: Euro,
-      //     key: EUR,
-      //     data: {
-      //       open: [...],
-      //       close: [...],
-      //       high: [...],
-      //       low: [...],
-      //       current: [...] 
-      //     }
-      //   }, 
-      //   {
-      //     label: Japanese Yen,
-      //     key: JPY
-      //   }, ...
-      // ]
-      moneyCurrencies: [],
-      comparisonData: {moneyCurrencies: []},
-      activeTab: 'JPY'
+      equipmentData: [],
+      comparisonData: {equipmentData: []},
+      activeTab: 'AMZN'
     }
   },
   async created() {
     var equipmentList = await this.getEquipmentList()
-    // Fill the moneyCurrencies with equipment list
+    // Fill the equipmentData with equipment list
     equipmentList.forEach(function(equipmentKey) {
-      this.moneyCurrencies.push({key: equipmentKey})
+      this.equipmentData.push({key: equipmentKey})
     }, this)
     var equipmentValues = await this.getEquipmentValues(equipmentList) 
     this.createRadarChartData(equipmentValues)
-    this.moneyCurrencies = equipmentValues
+    this.equipmentData = equipmentValues
     
-    this.comparisonData.moneyCurrencies = this.moneyCurrencies
+    this.comparisonData.equipmentData = this.equipmentData
   },
   methods: {
     // Promise for getting equipments list 
@@ -205,7 +187,7 @@ export default {
     },
 
     changeBaseofEquipment(equipmentLabel) {
-      this.moneyCurrencies.forEach(function(currency) {
+      this.equipmentData.forEach(function(currency) {
         if (currency.label == equipmentLabel) {
           console.log(currency)
           for (let i = 0; i < currency.data.open.length; i++) {


### PR DESCRIPTION
Hey,
With the PR #193 detailed page for money currencies were added. With this PR detailed pages for the rest of the equipment (stocks and crypto currencies) are added as well. Design and the look remains the same as Money Currencies page.
This PR will fix the issue #176 and #186. However regarding the issue #186 (reversing the base of the currencies), right now when "Change the Base" button is pressed the base doesn't change dynamically, when one of the other tabs are selected and then when we come back to the previous tab we see the changes. The problem is illustrated in the following GIF:

![cmpe352_te_detailed_reverse_base](https://user-images.githubusercontent.com/32496519/69475967-a2028480-0de4-11ea-9ba7-b3a65f2f7046.gif)

As can be seen the charts for ZenCash did not change when the button was pressed but it was changed when we updated the charts after going to BitCoin tab and returning. 
I believe we need to solve this before the Milestone II. That's why I will keep the issue #186 open. 

Other than that, the trading equipment parts are almost complete. And we are almost ready for the Milestone II.
It would be great if you take a look at the changes. 
Thanks!