### PR TITLE
[Backend] Alert endpoint

### DIFF
--- a/backend/TraderX/src/main/java/cmpe451/group6/Group6BackendService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/Group6BackendService.java
@@ -26,8 +26,6 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
-// TODO: Interface for user to supply new password when resent link is sent. (Frontend related.)
-
 @SpringBootApplication
 @EnableScheduling
 public class Group6BackendService implements CommandLineRunner {

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/controller/AlertController.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/controller/AlertController.java
@@ -29,7 +29,6 @@ public class AlertController {
 
     @PostMapping("/set")
     @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_TRADER')")
     @ApiOperation(value = "Set alert to sell/buy for specified equipment" +
             " when specified limit for the equipment is exceeded", response = StringResponseWrapper.class)
     @ApiResponses(value = {
@@ -42,7 +41,6 @@ public class AlertController {
 
     @GetMapping("/get")
     @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_TRADER')")
     @ApiOperation(value = "Get all alerts of the requester.", response = AlertResponseDTO.class, responseContainer = "List")
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = GlobalExceptionHandlerController.GENERIC_ERROR_RESPONSE),
@@ -53,7 +51,6 @@ public class AlertController {
 
     @DeleteMapping("/remove")
     @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_TRADER')")
     @ApiOperation(value = "Remove specified alert of the requester.", response = StringResponseWrapper.class)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = GlobalExceptionHandlerController.GENERIC_ERROR_RESPONSE),
@@ -64,7 +61,6 @@ public class AlertController {
 
     @PostMapping("/edit")
     @ResponseStatus(HttpStatus.OK)
-    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_TRADER')")
     @ApiOperation(value = "Edit specified alert of the requester.", response = StringResponseWrapper.class)
     @ApiResponses(value = {
             @ApiResponse(code = 400, message = GlobalExceptionHandlerController.GENERIC_ERROR_RESPONSE),

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/controller/AlertController.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/controller/AlertController.java
@@ -1,0 +1,77 @@
+package cmpe451.group6.rest.alert.controller;
+
+import cmpe451.group6.Util;
+import cmpe451.group6.authorization.dto.StringResponseWrapper;
+import cmpe451.group6.authorization.exception.GlobalExceptionHandlerController;
+import cmpe451.group6.rest.alert.dto.AlertDTO;
+import cmpe451.group6.rest.alert.dto.AlertEditDTO;
+import cmpe451.group6.rest.alert.dto.AlertResponseDTO;
+import cmpe451.group6.rest.alert.service.AlertService;
+import io.swagger.annotations.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
+@RestController
+@RequestMapping("/alert")
+@Api(tags = "Alert")
+public class AlertController {
+
+    @Autowired
+    Util util;
+
+    @Autowired
+    AlertService alertService;
+
+    @PostMapping("/set")
+    @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_TRADER')")
+    @ApiOperation(value = "Set alert to sell/buy for specified equipment" +
+            " when specified limit for the equipment is exceeded", response = StringResponseWrapper.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = GlobalExceptionHandlerController.GENERIC_ERROR_RESPONSE),
+            @ApiResponse(code = 417, message = "Invalid credentials. See detailed response message")})
+    public StringResponseWrapper setAlert(@ApiParam("Alert Details") @RequestBody AlertDTO alertDTO,
+                                          HttpServletRequest req) {
+        return new StringResponseWrapper(alertService.setAlert(alertDTO,util.unwrapUsername(req)));
+    }
+
+    @GetMapping("/get")
+    @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_TRADER')")
+    @ApiOperation(value = "Get all alerts of the requester.", response = AlertResponseDTO.class, responseContainer = "List")
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = GlobalExceptionHandlerController.GENERIC_ERROR_RESPONSE),
+            @ApiResponse(code = 417, message = "Invalid credentials. See detailed response message")})
+    public List<AlertResponseDTO> getAlerts(HttpServletRequest req) {
+        return alertService.getAlerts(util.unwrapUsername(req));
+    }
+
+    @DeleteMapping("/remove")
+    @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_TRADER')")
+    @ApiOperation(value = "Remove specified alert of the requester.", response = StringResponseWrapper.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = GlobalExceptionHandlerController.GENERIC_ERROR_RESPONSE),
+            @ApiResponse(code = 412, message = "No such an alert for the user.")})
+    public StringResponseWrapper removeAlert(@RequestParam int id, HttpServletRequest req) {
+        return new StringResponseWrapper(alertService.removeAlert(id,util.unwrapUsername(req)));
+    }
+
+    @PostMapping("/edit")
+    @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_TRADER')")
+    @ApiOperation(value = "Edit specified alert of the requester.", response = StringResponseWrapper.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = GlobalExceptionHandlerController.GENERIC_ERROR_RESPONSE),
+            @ApiResponse(code = 417, message = "Limit and amount must be positive values."),
+            @ApiResponse(code = 412, message = "No such alert found for the user.")})
+    public StringResponseWrapper removeAlert(@RequestBody AlertEditDTO alertEditDTO,
+                                             HttpServletRequest req) {
+        return new StringResponseWrapper(alertService.editAlert(alertEditDTO,util.unwrapUsername(req)));
+    }
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/dto/AlertDTO.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/dto/AlertDTO.java
@@ -1,0 +1,88 @@
+package cmpe451.group6.rest.alert.dto;
+
+import cmpe451.group6.authorization.exception.CustomException;
+import cmpe451.group6.rest.alert.model.AlertType;
+import cmpe451.group6.rest.transaction.model.TransactionType;
+import io.swagger.annotations.ApiModelProperty;
+import org.springframework.http.HttpStatus;
+
+import java.io.Serializable;
+
+public class AlertDTO implements Serializable {
+
+    @ApiModelProperty(position = 0, required = true)
+    private String code;
+    @ApiModelProperty(position = 1, required = true)
+    private String alertType;
+    @ApiModelProperty(position = 2, required = true)
+    private String transactionType;
+    @ApiModelProperty(position = 3, required = true)
+    private double limit;
+    @ApiModelProperty(position = 4, required = true)
+    private double amount;
+
+    public AlertDTO() {
+    }
+
+    public AlertDTO(String code, String alertType, String transactionType, double limit, double amount) {
+        this.code = code;
+        this.alertType = alertType;
+        this.transactionType = transactionType;
+        this.limit = limit;
+        this.amount = amount;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getAlertType() {
+        return alertType;
+    }
+
+    public void setAlertType(String alertType) {
+        this.alertType = alertType;
+    }
+
+    public String getTransactionType() {
+        return transactionType;
+    }
+
+    public void setTransactionType(String transactionType) {
+        this.transactionType = transactionType;
+    }
+
+    public double getLimit() {
+        return limit;
+    }
+
+    public void setLimit(double limit) {
+        this.limit = limit;
+    }
+
+    public double getAmount() {
+        return amount;
+    }
+
+    public void setAmount(double amount) {
+        this.amount = amount;
+    }
+
+    public static AlertType convertAlertType(String type){
+        if(type.equals("below")) return AlertType.BELOW;
+        if(type.equals("above")) return AlertType.ABOVE;
+        throw new CustomException(String.format("Invalid alert type: %s. use \"below\" or \"above\" only.", type),
+                HttpStatus.EXPECTATION_FAILED);//417
+    }
+
+    public static TransactionType convertTransactionType(String type){
+        if(type.equals("buy")) return TransactionType.BUY;
+        if(type.equals("sell")) return TransactionType.SELL;
+        throw new CustomException(String.format("Invalid transaction type: %s. use \"buy\" or \"sell\" only.", type),
+                HttpStatus.EXPECTATION_FAILED);//417
+    }
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/dto/AlertEditDTO.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/dto/AlertEditDTO.java
@@ -1,0 +1,46 @@
+package cmpe451.group6.rest.alert.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class AlertEditDTO {
+
+    @ApiModelProperty(position = 0, required = true)
+    private double newLimit;
+    @ApiModelProperty(position = 1, required = true)
+    private double newAmount;
+    @ApiModelProperty(position = 2, required = true)
+    private int alertId;
+
+    public AlertEditDTO() {
+    }
+
+    public AlertEditDTO(double newLimit, double newAmount, int alertId) {
+        this.newLimit = newLimit;
+        this.newAmount = newAmount;
+        this.alertId = alertId;
+    }
+
+    public int getAlertId() {
+        return alertId;
+    }
+
+    public void setAlertId(int alertId) {
+        this.alertId = alertId;
+    }
+
+    public double getNewLimit() {
+        return newLimit;
+    }
+
+    public void setNewLimit(double newLimit) {
+        this.newLimit = newLimit;
+    }
+
+    public double getNewAmount() {
+        return newAmount;
+    }
+
+    public void setNewAmount(double newAmount) {
+        this.newAmount = newAmount;
+    }
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/dto/AlertResponseDTO.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/dto/AlertResponseDTO.java
@@ -1,0 +1,85 @@
+package cmpe451.group6.rest.alert.dto;
+
+import cmpe451.group6.rest.alert.model.AlertType;
+import cmpe451.group6.rest.transaction.model.TransactionType;
+
+import java.util.Date;
+
+public class AlertResponseDTO {
+
+    private Integer id;
+    private Date createdAt;
+    private AlertType alertType;
+    private TransactionType transactionType;
+    private double limitValue;
+    private double amount;
+    private String username;
+    private String code;
+
+    public AlertResponseDTO() {
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public AlertType getAlertType() {
+        return alertType;
+    }
+
+    public void setAlertType(AlertType alertType) {
+        this.alertType = alertType;
+    }
+
+    public TransactionType getTransactionType() {
+        return transactionType;
+    }
+
+    public void setTransactionType(TransactionType transactionType) {
+        this.transactionType = transactionType;
+    }
+
+    public double getLimitValue() {
+        return limitValue;
+    }
+
+    public void setLimitValue(double limitValue) {
+        this.limitValue = limitValue;
+    }
+
+    public double getAmount() {
+        return amount;
+    }
+
+    public void setAmount(double amount) {
+        this.amount = amount;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/model/Alert.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/model/Alert.java
@@ -1,0 +1,114 @@
+package cmpe451.group6.rest.alert.model;
+
+import cmpe451.group6.authorization.model.User;
+import cmpe451.group6.rest.equipment.model.Equipment;
+import cmpe451.group6.rest.transaction.model.TransactionType;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.util.Date;
+
+@Entity
+public class Alert implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false, updatable = false)
+    private Date createdAt;
+
+    @Column(nullable = false)
+    private AlertType alertType;
+
+    @Column(nullable = false)
+    private TransactionType transactionType;
+
+    @Column(nullable = false)
+    private double limitValue;
+
+    @Column(nullable = false)
+    private double amount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fk_user", referencedColumnName = "username", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fk_equipment", referencedColumnName = "code", nullable = false)
+    private Equipment equipment;
+
+    public Alert() {
+    }
+
+    public Alert(AlertType alertType, TransactionType transactionType, double limitValue, double amount,
+                 User user, Equipment equipment, Date createdAt) {
+        this.alertType = alertType;
+        this.transactionType = transactionType;
+        this.limitValue = limitValue;
+        this.amount = amount;
+        this.user = user;
+        this.equipment = equipment;
+        this.createdAt = createdAt;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public AlertType getAlertType() {
+        return alertType;
+    }
+
+    public void setAlertType(AlertType alertType) {
+        this.alertType = alertType;
+    }
+
+    public TransactionType getTransactionType() {
+        return transactionType;
+    }
+
+    public void setTransactionType(TransactionType transactionType) {
+        this.transactionType = transactionType;
+    }
+
+    public double getAmount() {
+        return amount;
+    }
+
+    public void setAmount(double amount) {
+        this.amount = amount;
+    }
+
+    public double getLimitValue() {
+        return limitValue;
+    }
+
+    public void setLimitValue(double limitValue) {
+        this.limitValue = limitValue;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Equipment getEquipment() {
+        return equipment;
+    }
+
+    public void setEquipment(Equipment equipment) {
+        this.equipment = equipment;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/model/AlertType.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/model/AlertType.java
@@ -1,0 +1,5 @@
+package cmpe451.group6.rest.alert.model;
+
+public enum AlertType {
+    BELOW,ABOVE;
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/repository/AlertRepository.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/repository/AlertRepository.java
@@ -1,0 +1,16 @@
+package cmpe451.group6.rest.alert.repository;
+
+import cmpe451.group6.rest.alert.model.Alert;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+public interface AlertRepository extends JpaRepository<Alert,Integer> {
+
+    List<Alert> findAllByUser_Username(String username);
+
+    @Transactional
+    void deleteById(int id);
+
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/service/AlertService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/service/AlertService.java
@@ -1,0 +1,95 @@
+package cmpe451.group6.rest.alert.service;
+
+import cmpe451.group6.authorization.exception.CustomException;
+import cmpe451.group6.authorization.model.User;
+import cmpe451.group6.authorization.repository.UserRepository;
+import cmpe451.group6.rest.alert.dto.AlertDTO;
+import cmpe451.group6.rest.alert.dto.AlertEditDTO;
+import cmpe451.group6.rest.alert.dto.AlertResponseDTO;
+import cmpe451.group6.rest.alert.model.Alert;
+import cmpe451.group6.rest.alert.model.AlertType;
+import cmpe451.group6.rest.alert.repository.AlertRepository;
+import cmpe451.group6.rest.equipment.model.Equipment;
+import cmpe451.group6.rest.equipment.repository.EquipmentRepository;
+import cmpe451.group6.rest.transaction.model.TransactionType;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class AlertService {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    AlertRepository alertRepository;
+
+    @Autowired
+    EquipmentRepository equipmentRepository;
+
+    @Autowired
+    ModelMapper modelMapper;
+
+    public String setAlert(AlertDTO dto, String username){
+        User requester = userRepository.findByUsername(username);
+        // Username is fetched from token hence null check is not necessary
+
+        String code = dto.getCode();
+
+        Equipment equipment = equipmentRepository.findByCode(code);
+        if (equipment == null) throw new CustomException("Invalid equipment code: "+ code,
+                HttpStatus.EXPECTATION_FAILED);//417
+
+        AlertType alertType = AlertDTO.convertAlertType(dto.getAlertType());
+        TransactionType transactionType = AlertDTO.convertTransactionType(dto.getTransactionType());
+        if(dto.getLimit() < 0 || dto.getAmount() < 0) throw new
+                CustomException("Limit and amount must be positive values",HttpStatus.EXPECTATION_FAILED);//417
+
+        alertRepository.save(new Alert(alertType,transactionType,dto.getLimit(),
+                dto.getAmount(), requester, equipment, new Date()));
+        return "Alert is set for the equipment: " + code;
+    }
+
+    public List<AlertResponseDTO> getAlerts(String username){
+        // No need to auth check. Username is fetched from token.
+        List<Alert> result = alertRepository.findAllByUser_Username(username);
+        return result.stream().map(a -> {
+            AlertResponseDTO tmp = modelMapper.map(a,AlertResponseDTO.class);
+            tmp.setUsername(a.getUser().getUsername());
+            tmp.setCode(a.getEquipment().getCode());
+            return tmp;
+        }).collect(Collectors.toList());
+    }
+
+    public String removeAlert(int id, String requesterUsername){
+        nullCheckAndAuthorization(id,requesterUsername);
+        alertRepository.deleteById(id);
+        return "Alert has been removed: " + id;
+    }
+
+    public String editAlert(AlertEditDTO dto, String requesterUsername){
+        nullCheckAndAuthorization(dto.getAlertId(),requesterUsername);
+        if(dto.getNewLimit() < 0 || dto.getNewAmount() < 0) throw new
+                CustomException("Limit and amount must be positive values",HttpStatus.EXPECTATION_FAILED);//417
+        Alert alert = alertRepository.findOne(dto.getAlertId());
+        alert.setAmount(dto.getNewAmount());
+        alert.setLimitValue(dto.getNewLimit());
+        alertRepository.save(alert);
+        return "Alert has been updated.";
+    }
+
+    private void nullCheckAndAuthorization(int alertId, String requesterUsername){
+        Alert alert = alertRepository.findOne(alertId);
+        if (alert == null || !alert.getUser().getUsername().equals(requesterUsername)){
+            // Prevent to delete other's alerts.
+            throw new CustomException(String.format("No such alert for the user: %s, id: %d", requesterUsername,alertId),
+                    HttpStatus.PRECONDITION_FAILED); //412
+        }
+    }
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/equipment/dto/EquipmentResponseDTO.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/equipment/dto/EquipmentResponseDTO.java
@@ -1,14 +1,6 @@
 package cmpe451.group6.rest.equipment.dto;
 
-import cmpe451.group6.rest.equipment.model.Equipment;
 import cmpe451.group6.rest.equipment.model.EquipmentType;
-import cmpe451.group6.rest.equipment.model.HistoricalValue;
-import org.modelmapper.ModelMapper;
-
-import javax.persistence.Column;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import java.util.Date;
 import java.util.List;
 


### PR DESCRIPTION
Endpoints to set/edit/delete/get alert for equipments are implemented. Those alarms are supposed to be responsible for selling/buying equipment when a predefined limit for that equipment is exceeded.

This PR does not contain the auto-transaction mechanism yet. However, those endpoints will serve the purpose of frontend & android teams when implementing their alarm pages.

In the meantime we can add auto-transaction methods independent from the endpoints.