### PR TITLE
[Backend] Add alert executors

### DIFF
--- a/backend/TraderX/src/main/java/cmpe451/group6/Group6BackendService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/Group6BackendService.java
@@ -21,13 +21,17 @@ import org.springframework.context.annotation.Bean;
 
 import cmpe451.group6.authorization.model.Role;
 import cmpe451.group6.authorization.model.User;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 public class Group6BackendService implements CommandLineRunner {
 
   @Autowired
@@ -56,6 +60,16 @@ public class Group6BackendService implements CommandLineRunner {
 
   public static void main(String[] args) {
     SpringApplication.run(Group6BackendService.class, args);
+  }
+
+  @Bean(name="threadPoolTaskExecutor")
+  public TaskExecutor threadPoolTaskExecutor() {
+    ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
+    threadPoolTaskExecutor.setThreadNamePrefix("Async-");
+    threadPoolTaskExecutor.setCorePoolSize(3);
+    threadPoolTaskExecutor.setMaxPoolSize(3);
+    threadPoolTaskExecutor.afterPropertiesSet();
+    return threadPoolTaskExecutor;
   }
 
   @Bean

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/dto/AlertDTO.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/dto/AlertDTO.java
@@ -2,7 +2,7 @@ package cmpe451.group6.rest.alert.dto;
 
 import cmpe451.group6.authorization.exception.CustomException;
 import cmpe451.group6.rest.alert.model.AlertType;
-import cmpe451.group6.rest.transaction.model.TransactionType;
+import cmpe451.group6.rest.alert.model.OrderType;
 import io.swagger.annotations.ApiModelProperty;
 import org.springframework.http.HttpStatus;
 
@@ -15,7 +15,7 @@ public class AlertDTO implements Serializable {
     @ApiModelProperty(position = 1, required = true)
     private String alertType;
     @ApiModelProperty(position = 2, required = true)
-    private String transactionType;
+    private String orderType;
     @ApiModelProperty(position = 3, required = true)
     private double limit;
     @ApiModelProperty(position = 4, required = true)
@@ -24,10 +24,10 @@ public class AlertDTO implements Serializable {
     public AlertDTO() {
     }
 
-    public AlertDTO(String code, String alertType, String transactionType, double limit, double amount) {
+    public AlertDTO(String code, String alertType, String orderType, double limit, double amount) {
         this.code = code;
         this.alertType = alertType;
-        this.transactionType = transactionType;
+        this.orderType = orderType;
         this.limit = limit;
         this.amount = amount;
     }
@@ -48,12 +48,12 @@ public class AlertDTO implements Serializable {
         this.alertType = alertType;
     }
 
-    public String getTransactionType() {
-        return transactionType;
+    public String getOrderType() {
+        return orderType;
     }
 
-    public void setTransactionType(String transactionType) {
-        this.transactionType = transactionType;
+    public void setOrderType(String orderType) {
+        this.orderType = orderType;
     }
 
     public double getLimit() {
@@ -79,10 +79,11 @@ public class AlertDTO implements Serializable {
                 HttpStatus.EXPECTATION_FAILED);//417
     }
 
-    public static TransactionType convertTransactionType(String type){
-        if(type.equals("buy")) return TransactionType.BUY;
-        if(type.equals("sell")) return TransactionType.SELL;
-        throw new CustomException(String.format("Invalid transaction type: %s. use \"buy\" or \"sell\" only.", type),
+    public static OrderType convertOrderType(String type){
+        if(type.equals("notify")) return OrderType.NOTIFY;
+        if(type.equals("buy")) return OrderType.BUY;
+        if(type.equals("sell")) return OrderType.SELL;
+        throw new CustomException(String.format("Invalid order type: %s. use \"buy\" or \"sell\" or \"notify\" only.", type),
                 HttpStatus.EXPECTATION_FAILED);//417
     }
 }

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/dto/AlertResponseDTO.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/dto/AlertResponseDTO.java
@@ -1,6 +1,7 @@
 package cmpe451.group6.rest.alert.dto;
 
 import cmpe451.group6.rest.alert.model.AlertType;
+import cmpe451.group6.rest.alert.model.OrderType;
 import cmpe451.group6.rest.transaction.model.TransactionType;
 
 import java.util.Date;
@@ -10,7 +11,7 @@ public class AlertResponseDTO {
     private Integer id;
     private Date createdAt;
     private AlertType alertType;
-    private TransactionType transactionType;
+    private OrderType orderType;
     private double limitValue;
     private double amount;
     private String username;
@@ -43,12 +44,12 @@ public class AlertResponseDTO {
         this.alertType = alertType;
     }
 
-    public TransactionType getTransactionType() {
-        return transactionType;
+    public OrderType getOrderType() {
+        return orderType;
     }
 
-    public void setTransactionType(TransactionType transactionType) {
-        this.transactionType = transactionType;
+    public void setOrderType(OrderType orderType) {
+        this.orderType = orderType;
     }
 
     public double getLimitValue() {

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/model/Alert.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/model/Alert.java
@@ -2,7 +2,6 @@ package cmpe451.group6.rest.alert.model;
 
 import cmpe451.group6.authorization.model.User;
 import cmpe451.group6.rest.equipment.model.Equipment;
-import cmpe451.group6.rest.transaction.model.TransactionType;
 
 import javax.persistence.*;
 import java.io.Serializable;
@@ -22,7 +21,7 @@ public class Alert implements Serializable {
     private AlertType alertType;
 
     @Column(nullable = false)
-    private TransactionType transactionType;
+    private OrderType orderType;
 
     @Column(nullable = false)
     private double limitValue;
@@ -41,10 +40,10 @@ public class Alert implements Serializable {
     public Alert() {
     }
 
-    public Alert(AlertType alertType, TransactionType transactionType, double limitValue, double amount,
+    public Alert(AlertType alertType, OrderType orderType, double limitValue, double amount,
                  User user, Equipment equipment, Date createdAt) {
         this.alertType = alertType;
-        this.transactionType = transactionType;
+        this.orderType = orderType;
         this.limitValue = limitValue;
         this.amount = amount;
         this.user = user;
@@ -64,12 +63,12 @@ public class Alert implements Serializable {
         this.alertType = alertType;
     }
 
-    public TransactionType getTransactionType() {
-        return transactionType;
+    public OrderType getOrderType() {
+        return orderType;
     }
 
-    public void setTransactionType(TransactionType transactionType) {
-        this.transactionType = transactionType;
+    public void setOrderType(OrderType orderType) {
+        this.orderType = orderType;
     }
 
     public double getAmount() {

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/model/OrderType.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/model/OrderType.java
@@ -1,0 +1,5 @@
+package cmpe451.group6.rest.alert.model;
+
+public enum OrderType {
+    BUY, SELL, NOTIFY;
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/repository/AlertRepository.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/repository/AlertRepository.java
@@ -10,6 +10,8 @@ public interface AlertRepository extends JpaRepository<Alert,Integer> {
 
     List<Alert> findAllByUser_Username(String username);
 
+    List<Alert> findAllByEquipment_Code(String code);
+
     @Transactional
     void deleteById(int id);
 

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/equipment/service/EquipmentUpdateService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/equipment/service/EquipmentUpdateService.java
@@ -1,5 +1,6 @@
 package cmpe451.group6.rest.equipment.service;
 
+import cmpe451.group6.rest.alert.service.AlertService;
 import cmpe451.group6.rest.equipment.alpha.api.*;
 import cmpe451.group6.rest.equipment.model.Equipment;
 import cmpe451.group6.rest.equipment.model.EquipmentType;
@@ -32,6 +33,9 @@ public class EquipmentUpdateService {
 
     @Autowired
     HistoricalValueRepository historicalValueRepository;
+
+    @Autowired
+    AlertService alertService;
 
     private String apiKey1;
 
@@ -213,6 +217,7 @@ public class EquipmentUpdateService {
             equipment.setCurrentValue(1/equipment.getCurrentValue());
         }
         equipmentRepository.save(equipment);
+        alertService.handleAlerts(code);
     }
 
 


### PR DESCRIPTION
* Async executor for transaction operations specified by alerts are implemented. They are triggered for every update of an equipment's current value.
* `transactionType` has been renamed to `orderType`
*  `notify` option is added. If specified, no buy/sell actions will be taken but user will be notified only.

