### PR TITLE
[Backend] Add vote service for comments

### DIFF
--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/comment/model/CommentResponseDTO.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/comment/model/CommentResponseDTO.java
@@ -14,12 +14,21 @@ public class CommentResponseDTO {
 
     private String equipment;
 
-    public CommentResponseDTO(int id, Date lastModifiedTime, String comment, String author, String equipment) {
+    private int likes;
+
+    private int dislikes;
+
+    private VoteStatus status;
+
+    public CommentResponseDTO(int id, Date lastModifiedTime, String comment, String author, String equipment,int likes, int dislikes ,VoteStatus status) {
         this.id = id;
         this.lastModifiedTime = lastModifiedTime;
         this.comment = comment;
         this.author = author;
         this.equipment = equipment;
+        this.likes = likes;
+        this.dislikes = dislikes;
+        this.status = status;
     }
 
     public int getId() {
@@ -60,5 +69,33 @@ public class CommentResponseDTO {
 
     public void setEquipment(String equipment) {
         this.equipment = equipment;
+    }
+
+    public int getLikes() {
+        return likes;
+    }
+
+    public void setLikes(int likes) {
+        this.likes = likes;
+    }
+
+    public int getDislikes() {
+        return dislikes;
+    }
+
+    public void setDislikes(int dislikes) {
+        this.dislikes = dislikes;
+    }
+
+    public VoteStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(VoteStatus status) {
+        this.status = status;
+    }
+
+    public enum VoteStatus {
+        LIKED,DISLIKED,NOT_COMMENTED
     }
 }

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/comment/model/CommentVote.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/comment/model/CommentVote.java
@@ -1,0 +1,67 @@
+package cmpe451.group6.rest.comment.model;
+
+import cmpe451.group6.authorization.model.User;
+import cmpe451.group6.rest.equipment.model.Equipment;
+
+import javax.persistence.*;
+
+@Entity
+public class CommentVote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id", updatable = false, nullable = false)
+    private int id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fk_comment", referencedColumnName = "id")
+    private EquipmentComment equipmentComment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fk_user", referencedColumnName = "username")
+    private User owner;
+
+    @Column
+    private boolean upvote;
+
+    public CommentVote(EquipmentComment equipmentComment, User owner, boolean upvote) {
+        this.equipmentComment = equipmentComment;
+        this.owner = owner;
+        this.upvote = upvote;
+    }
+
+    public CommentVote() {
+    }
+
+    public User getOwner() {
+        return owner;
+    }
+
+    public void setOwner(User owner) {
+        this.owner = owner;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public EquipmentComment getEquipmentComment() {
+        return equipmentComment;
+    }
+
+    public void setEquipmentComment(EquipmentComment equipmentComment) {
+        this.equipmentComment = equipmentComment;
+    }
+
+    public boolean getUpvote() {
+        return upvote;
+    }
+
+    public void setUpvote(boolean upvote) {
+        this.upvote = upvote;
+    }
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/comment/repository/CommentVoteRepository.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/comment/repository/CommentVoteRepository.java
@@ -1,0 +1,21 @@
+package cmpe451.group6.rest.comment.repository;
+
+import cmpe451.group6.rest.comment.model.CommentVote;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface CommentVoteRepository extends JpaRepository<CommentVote,Integer> {
+
+    @Override
+    List<CommentVote> findAll();
+
+    CommentVote findByOwner_UsernameAndEquipmentComment_Id(String username, int id);
+
+    int countAllByEquipmentComment_IdAndUpvoteIsTrue(int commentId);
+
+    int countAllByEquipmentComment_IdAndUpvoteIsFalse(int commentId);
+
+}
+

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/equipment/model/Equipment.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/equipment/model/Equipment.java
@@ -37,7 +37,6 @@ public class Equipment implements Serializable {
     @Column(nullable = false)
     private double predictionRate;
 
-
     @Column(nullable = false)
     private EquipmentType equipmentType;
 


### PR DESCRIPTION
Voting endpoint are implemented. New response type is as follows:
```json
[
    {
        "id": 1,
        "lastModifiedTime": 1576009589000,
        "comment": "comment content",
        "author": "admin",
        "equipment": "USD",
        "likes": 0,
        "dislikes": 1,
        "status": "DISLIKED"
    }
]
```
`status` field denotes if the request sender has a vote on this comment. This might be useful when showing a comment with like/dislike button. (i.e. if status is "LIKED", highlight the button with green etc.)
Available status types are : `LIKED, DISLIKED, NOT_COMMENTED`
(cc @irmakguzey)
