### PR TITLE
[Backend] Notification service

### DIFF
--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/service/AlertService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/alert/service/AlertService.java
@@ -136,13 +136,17 @@ public class AlertService {
                 case BUY:
                     transactionService.buyAsset(username,code,amount);
                     notificationType = NotificationType.ALERT_TRANSACTION_SUCCESS;
+                    message = String.format("%.2f %s has been bought.", amount,code);
                     break;
                 case SELL:
                     transactionService.sellAsset(username,code,amount);
                     notificationType = NotificationType.ALERT_TRANSACTION_SUCCESS;
+                    message = String.format("%.2f %s has been sold.", amount,code);
                     break;
                 case NOTIFY:
                     notificationType = NotificationType.ALERT_NOTIFY;
+                    String status = alert.getAlertType() == AlertType.ABOVE ? "exceeded" : "dropped below";
+                    message = String.format("Limit %.2f has been %s for %s", amount, status, code);
                     break;
             }
         } catch (Exception e) {
@@ -156,6 +160,7 @@ public class AlertService {
                             code,
                             alert.getOrderType().name(),
                             Double.toString(alert.getAmount()),
+                            Double.toString(alert.getLimitValue()),
                             message
                     });
         }

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/Notification.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/Notification.java
@@ -16,7 +16,7 @@ public class Notification {
     @Column(nullable = false, updatable = false)
     private Date created;
 
-    @Column(nullable = false, updatable = false)
+    @Column(nullable = false)
     private boolean isNew;
 
     @Column(nullable = false, updatable = false)

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/Notification.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/Notification.java
@@ -1,0 +1,97 @@
+package cmpe451.group6.rest.notification;
+
+import cmpe451.group6.authorization.model.User;
+import javax.persistence.*;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Entity
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false, updatable = false)
+    private Date created;
+
+    @Column(nullable = false, updatable = false)
+    private boolean isNew;
+
+    @Column(nullable = false, updatable = false)
+    private NotificationType type;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "fk_notification_owner", referencedColumnName = "username", nullable = false)
+    private User owner;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @MapKeyColumn(name="name")
+    @Column(name="value")
+    @CollectionTable(name="notification_payload", joinColumns=@JoinColumn(name="notification_id"))
+    private Map<String, String> payload = new HashMap<String, String>();
+
+    public Notification() {
+    }
+
+    public Notification(NotificationType type, User owner, boolean isNew) {
+        this.type = type;
+        this.owner = owner;
+        this.isNew = true;
+    }
+
+    public NotificationType getType() {
+        return type;
+    }
+
+    public void setType(NotificationType type) {
+        this.type = type;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Date getCreated() {
+        return created;
+    }
+
+    public void setCreated(Date created) {
+        this.created = created;
+    }
+
+    public User getOwner() {
+        return owner;
+    }
+
+    public void setOwner(User owner) {
+        this.owner = owner;
+    }
+
+    public Map<String, String> getPayload() {
+        return payload;
+    }
+
+    public void setPayload(Map<String, String> payload) {
+        this.payload = payload;
+    }
+
+    public boolean getIsNew() {
+        return isNew;
+    }
+
+    public void setIsNew(boolean aNew) {
+        isNew = aNew;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        created = new Date();
+    }
+
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/NotificationController.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/NotificationController.java
@@ -1,4 +1,64 @@
 package cmpe451.group6.rest.notification;
 
+
+import cmpe451.group6.Util;
+import cmpe451.group6.authorization.exception.GlobalExceptionHandlerController;
+import io.swagger.annotations.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
+@RestController
+@RequestMapping("/notification")
+@Api(tags = "Notifications")
 public class NotificationController {
+
+    @Autowired
+    Util util;
+
+    @Autowired
+    NotificationService notificationService;
+
+    @GetMapping("")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "Gets all notifications for requester (including not new ones)",
+            response = NotificationDTO.class, responseContainer = "List")
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = GlobalExceptionHandlerController.GENERIC_ERROR_RESPONSE)})
+    public List<NotificationDTO> getAll(HttpServletRequest req) {
+        return notificationService.getAll(util.unwrapUsername(req));
+    }
+
+    @GetMapping("/news")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "Gets only new notifications for requester",
+            response = NotificationDTO.class, responseContainer = "List")
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = GlobalExceptionHandlerController.GENERIC_ERROR_RESPONSE)})
+    public List<NotificationDTO> getNews(HttpServletRequest req) {
+        return notificationService.getAllNews(util.unwrapUsername(req));
+    }
+
+    @PostMapping("/read")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "Mark new notifications as not new.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = GlobalExceptionHandlerController.GENERIC_ERROR_RESPONSE)})
+    public void clear(HttpServletRequest req) {
+         notificationService.readAll(util.unwrapUsername(req));
+    }
+
+    @DeleteMapping("/delete")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "Delete all notifications permanently.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 400, message = GlobalExceptionHandlerController.GENERIC_ERROR_RESPONSE)})
+    public void delete(HttpServletRequest req) {
+        notificationService.deleteAll(util.unwrapUsername(req));
+    }
+
+
 }

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/NotificationController.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/NotificationController.java
@@ -1,0 +1,4 @@
+package cmpe451.group6.rest.notification;
+
+public class NotificationController {
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/NotificationDTO.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/NotificationDTO.java
@@ -1,0 +1,62 @@
+package cmpe451.group6.rest.notification;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+public class NotificationDTO implements Serializable {
+
+    @ApiModelProperty(position = 0, required = true)
+    private Date created;
+    @ApiModelProperty(position = 1, required = true)
+    private boolean isNew;
+    @ApiModelProperty(position = 2, required = true)
+    private NotificationType type;
+    @ApiModelProperty(position = 3, required = true)
+    private Map<String, String> payload = new HashMap<String, String>();
+
+    public NotificationDTO() {
+    }
+
+    public NotificationDTO(Notification notification) {
+        this.created = notification.getCreated();
+        this.isNew = notification.getIsNew();
+        this.type = notification.getType();
+        this.payload = notification.getPayload();
+    }
+
+    public Date getCreated() {
+        return created;
+    }
+
+    public void setCreated(Date created) {
+        this.created = created;
+    }
+
+    public boolean getIsNew() {
+        return isNew;
+    }
+
+    public void setIsNew(boolean aNew) {
+        isNew = aNew;
+    }
+
+    public NotificationType getType() {
+        return type;
+    }
+
+    public void setType(NotificationType type) {
+        this.type = type;
+    }
+
+    public Map<String, String> getPayload() {
+        return payload;
+    }
+
+    public void setPayload(Map<String, String> payload) {
+        this.payload = payload;
+    }
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/NotificationRepository.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/NotificationRepository.java
@@ -2,6 +2,7 @@ package cmpe451.group6.rest.notification;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import javax.transaction.Transactional;
 import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Integer> {
@@ -10,4 +11,12 @@ public interface NotificationRepository extends JpaRepository<Notification, Inte
     List<Notification> findAll();
 
     Notification findById(int id);
+
+    List<Notification> findByOwner_Username(String username);
+
+    List<Notification> findByOwner_UsernameAndIsNewIsTrue(String username);
+
+    @Transactional
+    void deleteAllByOwner_Username(String username);
+
 }

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/NotificationRepository.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/NotificationRepository.java
@@ -1,0 +1,13 @@
+package cmpe451.group6.rest.notification;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Integer> {
+
+    @Override
+    List<Notification> findAll();
+
+    Notification findById(int id);
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/NotificationService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/NotificationService.java
@@ -1,0 +1,29 @@
+package cmpe451.group6.rest.notification;
+
+import cmpe451.group6.authorization.model.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NotificationService {
+
+    @Autowired
+    NotificationRepository notificationRepository;
+
+    public void createNotification(User owner, NotificationType type, String[] payload) throws IllegalArgumentException{
+        String[] payloadHeaders = NotificationType.payloadHeaders(type);
+        if (payload.length != payloadHeaders.length){
+            throw new IllegalArgumentException("Payload element sizes are not matched");
+        }
+        Notification notification = new Notification(type,owner,true);
+        for (int i = 0; i < payloadHeaders.length; i++) {
+            notification.getPayload().put(payloadHeaders[i],payload[i]);
+        }
+        notificationRepository.save(notification);
+    }
+
+    public void clearNotifications(String username){
+        //
+    }
+
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/NotificationService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/NotificationService.java
@@ -4,11 +4,33 @@ import cmpe451.group6.authorization.model.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 public class NotificationService {
 
     @Autowired
     NotificationRepository notificationRepository;
+
+    public List<NotificationDTO> getAll(String username){
+        return notificationRepository.findByOwner_Username(username).stream().map(NotificationDTO::new).collect(Collectors.toList());
+    }
+
+    public List<NotificationDTO> getAllNews(String username){
+        return notificationRepository.findByOwner_UsernameAndIsNewIsTrue(username).stream().map(NotificationDTO::new).collect(Collectors.toList());
+    }
+
+    public void readAll(String username){
+        notificationRepository.findByOwner_UsernameAndIsNewIsTrue(username).forEach(n -> {
+            n.setIsNew(false);
+            notificationRepository.save(n);
+        });
+    }
+
+    public void deleteAll(String username){
+        notificationRepository.deleteAllByOwner_Username(username);
+    }
 
     public void createNotification(User owner, NotificationType type, String[] payload) throws IllegalArgumentException{
         String[] payloadHeaders = NotificationType.payloadHeaders(type);
@@ -20,10 +42,6 @@ public class NotificationService {
             notification.getPayload().put(payloadHeaders[i],payload[i]);
         }
         notificationRepository.save(notification);
-    }
-
-    public void clearNotifications(String username){
-        //
     }
 
 }

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/NotificationType.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/NotificationType.java
@@ -2,7 +2,6 @@ package cmpe451.group6.rest.notification;
 
 public enum NotificationType {
 
-
     ALERT_TRANSACTION_SUCCESS,
     ALERT_TRANSACTION_FAIL,
     ALERT_NOTIFY,
@@ -12,7 +11,7 @@ public enum NotificationType {
     FOLLOW_REQUEST_ACCEPTED,
     FOLLOW_REQUEST_DENIED;
 
-    private static final String[] ALERT_HEADERS = new String[]{"alertId","timestamp","code","type","amount","message"};
+    private static final String[] ALERT_HEADERS = new String[]{"alertId","timestamp","code","type","amount","limit","message"};
     private static final String[] FOLLOW_HEADERS = new String[]{"username"};
 
     static String[] payloadHeaders(NotificationType type){

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/NotificationType.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/notification/NotificationType.java
@@ -1,0 +1,33 @@
+package cmpe451.group6.rest.notification;
+
+public enum NotificationType {
+
+
+    ALERT_TRANSACTION_SUCCESS,
+    ALERT_TRANSACTION_FAIL,
+    ALERT_NOTIFY,
+
+    FOLLOW_REQUESTED,
+    FOLLOWED,
+    FOLLOW_REQUEST_ACCEPTED,
+    FOLLOW_REQUEST_DENIED;
+
+    private static final String[] ALERT_HEADERS = new String[]{"alertId","timestamp","code","type","amount","message"};
+    private static final String[] FOLLOW_HEADERS = new String[]{"username"};
+
+    static String[] payloadHeaders(NotificationType type){
+        switch (type) {
+            case ALERT_TRANSACTION_SUCCESS:
+            case ALERT_TRANSACTION_FAIL:
+            case ALERT_NOTIFY:
+                return ALERT_HEADERS;
+            case FOLLOW_REQUESTED:
+            case FOLLOWED:
+            case FOLLOW_REQUEST_ACCEPTED:
+            case FOLLOW_REQUEST_DENIED:
+                return FOLLOW_HEADERS;
+        }
+        return new String[]{};
+    }
+
+}


### PR DESCRIPTION
The PR contains notification service implementation. Details are below.

Currently two type of notifications exist:
* **Alert**
Notifies upon an ordered event occur for equipments concerning their values.
Types:     `ALERT_TRANSACTION_SUCCESS,
    ALERT_TRANSACTION_FAIL,
    ALERT_NOTIFY`  
* **Follow**
Notifies upon a following event occur.
Types: `FOLLOW_REQUESTED,
    FOLLOWED,
    FOLLOW_REQUEST_ACCEPTED,
    FOLLOW_REQUEST_DENIED`

 

1. Both types have these common fields: `created, isNew, type, payload`

2. `payload` is a map and differs according to `ALERT` or `FOLLOW` types.

3. `payload` keys are the same for subtypes of a notification type. That is, `FOLLOWED, FOLLOW_REQUEST_ACCEPTED, etc.` will have only one payload key: `username` and all alert related notifications will contain `amount, code, limit` etc. fields.

---
* Endpoints
`/notification` : `[GET]` Get all notifications for requester (including not new ones)
`/notification/news` : `[GET]` Get only new notifications for requester
`/notification/read` : `[POST]` Mark new notifications as not new.
`/notification/delete` : `[DELETE]` Delete all notifications permanently.

---
Sample response:
```json
[
    {
        "created": 1576108426000,
        "isNew": true,
        "type": "FOLLOW_REQUESTED",
        "payload": {
            "username": "trader"
        }
    },
    {
        "created": 1576108501000,
        "isNew": true,
        "type": "ALERT_NOTIFY",
        "payload": {
            "amount": "0.0",
            "code": "TRY",
            "limit": "0.0",
            "alertId": "1",
            "message": "Limit 0.00 has been exceeded for TRY",
            "type": "NOTIFY",
            "timestamp": "1576108501108"
        }
    }
]
```