### PR TITLE
[Backend] Event service

### DIFF
--- a/backend/TraderX/src/main/java/cmpe451/group6/Group6BackendService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/Group6BackendService.java
@@ -8,6 +8,7 @@ import cmpe451.group6.authorization.model.RegistrationStatus;
 import cmpe451.group6.authorization.repository.UserRepository;
 import cmpe451.group6.authorization.service.SignupService;
 import cmpe451.group6.rest.equipment.service.EquipmentUpdateService;
+import cmpe451.group6.rest.event.service.EventService;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,6 +37,9 @@ public class Group6BackendService implements CommandLineRunner {
 
   @Autowired
   EquipmentUpdateService equipmentUpdateService;
+
+  @Autowired
+  EventService eventService;
 
   @Autowired
   UserRepository userRepository;
@@ -95,6 +99,7 @@ public class Group6BackendService implements CommandLineRunner {
     }
 
     equipmentUpdateService.initializeEquipments();
+    eventService.initializeIfRequired();
 
   }
 

--- a/backend/TraderX/src/main/java/cmpe451/group6/authorization/security/WebSecurityConfig.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/authorization/security/WebSecurityConfig.java
@@ -46,6 +46,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         .antMatchers("/transaction/byDate").permitAll()
         .antMatchers("/transaction/count/all").permitAll()
         .antMatchers("/transaction/count/equipment/**").permitAll()
+        .antMatchers("/events").permitAll()
         // Disallow everything else..
         .anyRequest().authenticated();
 
@@ -79,6 +80,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         .antMatchers("/transaction/byDate")
         .antMatchers("/transaction/count/all")
         .antMatchers("/transaction/count/equipment/**")
+        .antMatchers("/events")
         
         // Un-secure H2 Database (for testing purposes, H2 console shouldn't be unprotected in production)
         .and()

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/event/controller/EventController.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/event/controller/EventController.java
@@ -1,0 +1,42 @@
+package cmpe451.group6.rest.event.controller;
+
+import cmpe451.group6.authorization.exception.GlobalExceptionHandlerController;
+import cmpe451.group6.rest.event.service.EventService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/events")
+@Api(tags = "Economic Events")
+public class EventController {
+
+    @Autowired
+    EventService eventService;
+
+    @GetMapping(value = "")
+    @ApiOperation(value = "Get economic events")
+    @ApiResponses(value = {//
+            @ApiResponse(code = 400, message = GlobalExceptionHandlerController.GENERIC_ERROR_RESPONSE)
+    })
+    public String getCalendar() {
+        return eventService.getCalendar();
+    }
+
+    @PostMapping(value = "/force")
+    @ApiOperation(value = "Force to update immediately. (Ignore this, Admin only.)")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @ApiResponses(value = {//
+            @ApiResponse(code = 400, message = GlobalExceptionHandlerController.GENERIC_ERROR_RESPONSE)
+    })
+    public void force() {
+        eventService.forceUpdate();
+    }
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/event/model/EventsJson.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/event/model/EventsJson.java
@@ -1,0 +1,37 @@
+package cmpe451.group6.rest.event.model;
+
+import javax.persistence.*;
+
+@Entity
+public class EventsJson {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false, updatable = false, length = 10000)
+    private String json;
+
+    public EventsJson() {
+    }
+
+    public EventsJson(String json) {
+        this.json = json;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getJson() {
+        return json;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public void setJson(String json) {
+        this.json = json;
+    }
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/event/repository/EventRepository.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/event/repository/EventRepository.java
@@ -1,0 +1,12 @@
+package cmpe451.group6.rest.event.repository;
+
+import cmpe451.group6.rest.event.model.EventsJson;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<EventsJson,Integer> {
+
+    EventsJson findById(int id);
+
+    boolean existsById(int id);
+
+}

--- a/backend/TraderX/src/main/java/cmpe451/group6/rest/event/service/EventService.java
+++ b/backend/TraderX/src/main/java/cmpe451/group6/rest/event/service/EventService.java
@@ -1,0 +1,89 @@
+package cmpe451.group6.rest.event.service;
+
+import cmpe451.group6.authorization.exception.CustomException;
+import cmpe451.group6.rest.event.model.EventsJson;
+import cmpe451.group6.rest.event.repository.EventRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.logging.Logger;
+
+@Service
+public class EventService {
+
+    private final static String URI = "http://api.tradingeconomics.com/calendar?c=guest:guest&format=json";
+
+    private Logger logger = Logger.getLogger(EventService.class.getName());
+
+    @Autowired
+    EventRepository eventRepository;
+
+    public String getCalendar(){
+        EventsJson data = eventRepository.findById(1);
+        if (data == null){
+            throw new CustomException("Unable to serve events now.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        return data.getJson();
+    }
+
+    public void initializeIfRequired(){
+        if (eventRepository.existsById(1)){
+            // already initialized
+            logger.info("Event initialization is skipped: Already initialized.");
+            return;
+        }
+        updateEvents();
+    }
+
+    public void forceUpdate(){
+        logger.info("Events are being updated forcefully...");
+        updateEvents();
+    }
+
+    private String getEventsFromSource() throws IOException
+    {
+        URL obj = new URL(URI);
+        HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+        BufferedReader in;
+        in = new BufferedReader(
+                new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+        return response.toString();
+    }
+
+    private void updateEvents(){
+        String newData = null;
+        try {
+            newData = getEventsFromSource();
+        } catch (IOException e) {
+            logger.severe("Failed to get events data from 3rd party service. Update is aborted.");
+        }
+        EventsJson currentData = eventRepository.findById(1); // There will be one entry only.
+        if (currentData == null) { // initialize for the first time
+            eventRepository.save(new EventsJson(newData));
+            logger.info("Events have been initialized.");
+        } else {
+            currentData.setJson(newData);
+            eventRepository.save(currentData);
+            logger.info("Events have been updated.");
+        }
+    }
+
+    @Scheduled(cron = "0 0 8 * * *")
+    public void updateEventsScheduled(){
+        updateEvents();
+    }
+
+}


### PR DESCRIPTION
The PR contains the service for economic events. Events are fetched from `tradingeconomics` 3rd party service and updated at 8 A.M (UTC+3) everyday. Since no further operations concerning events (e.g. comment, follow, like etc.) are required, the system only stores the json data itself coming from the service. Thus, there is no explicit model for economic events. Also, history is not being saved. Only that day's events are served.

The original response can be seen [here.](https://api.tradingeconomics.com/calendar?c=guest:guest&format=json)

Endpoint: `[GET] /events`

Response: (as String) 
```json
[
    {
        "CalendarId": "196769",
        "Date": "2019-12-15T11:10:00",
        "Country": "Israel",
        "Category": "Current Account",
        "Event": "Current Account",
        "Reference": "Q3",
        "Source": "Central Bureau of Statistics, Israel",
        "Actual": "$3.9B",
        "Previous": "$4.2B",
        "Forecast": "",
        "TEForecast": "$3.2B",
        "URL": "/israel/current-account",
        "DateSpan": "0",
        "Importance": 1,
        "LastUpdate": "2019-12-15T11:10:00",
        "Revised": "",
        "Currency": "",
        "Unit": "",
        "OCountry": "Israel",
        "OCategory": "Current Account",
        "Ticker": "ISCAL",
        "Symbol": "ISCAL"
    },
    {
        ...
    }
   
]
```