### PR TITLE
[Frontend] Added Image Annotations

### DIFF
--- a/frontend/TraderX/public/index.html
+++ b/frontend/TraderX/public/index.html
@@ -10,6 +10,8 @@
     <script src="https://apis.google.com/js/platform.js"></script>
     <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCaUU-LjlFQl4cxNsKAYihCAiuDTIgy-jw&callback=initMap"
       type="text/javascript"></script>
+    <link type="text/css" rel="stylesheet" href="http://annotorious.github.com/latest/annotorious.css"/>
+    <script type="text/javascript" src="http://annotorious.github.com/latest/annotorious.min.js"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/frontend/TraderX/src/api/annotation.js
+++ b/frontend/TraderX/src/api/annotation.js
@@ -1,0 +1,34 @@
+import request from '@/utils/request'
+
+export function getAnnotationList(articleId) {
+  return request({
+    url: '/annotation/all/' + articleId,
+    method: 'get',
+  })
+}
+
+export function createAnnotation(data) {
+  return request({
+    url: '/annotation/create',
+    method: 'post',
+    data
+  })
+}
+
+export function updateAnnotation(data) {
+    return request({
+      url: '/annotation/update',
+      method: 'post',
+      data
+    })
+  }
+
+export function deleteAnnotation(query) {
+  return request({
+    url: '/annotation/delete',
+    method: 'delete',
+    params: query
+  })
+}
+
+

--- a/frontend/TraderX/src/views/view-article/index.vue
+++ b/frontend/TraderX/src/views/view-article/index.vue
@@ -5,17 +5,25 @@
         <div class="title-wrapper">
           <p style="font-size: 40px"><b>{{ this.title.toUpperCase() }}</b></p>
         </div>
+
         <a @click="redirectToUser()" style="">
-          <img src="https://www.sackettwaconia.com/wp-content/uploads/default-profile.png" class="user-avatar">
+          <img draggable="false" src="https://www.sackettwaconia.com/wp-content/uploads/default-profile.png" class="user-avatar">
           <div class="author-wrapper" style="float: left">
             <p style="font-size: 20px"><b>{{ this.author }}</b></p>
           </div>
         </a>
+
+        <div id="annotation">
+          <!-- <button @click="drawing = !drawing">{{drawing ? "stop" : "drawing" }}</button> -->
+          
+        </div>
+          
+        
         <div style="float: right">
           <p style="font-size: 20px">Publish Time: <b>{{ this.date }}</b></p>
         </div>
         <div>
-          <img style="padding-top:30px;width: 100%; height: 100%;" src="https://i.sozcu.com.tr/wp-content/uploads/2019/12/09/iecrop/sis-bursa-sis-iha1_10228788_16_9_1575927508-880x495.jpg" alt="">
+          <img id="articleImage" class="annotatable" :src="articleImageUrl">
         </div>
         <div class="body-wrapper" style="float: right; padding-top: 30px; padding-bottom: 30px">
           <p style="font-size: 21px">{{ this.body }}</p>
@@ -27,9 +35,15 @@
 
 <script>
 import PanThumb from '@/components/PanThumb'
+import annotator from 'annotator'
+import VAnnotator from 'vue-annotator'
+import 'annotorious'
 
 export default {
-  components: { PanThumb },
+  components: { 
+    PanThumb,
+    VAnnotator
+  },
   name: 'ViewArticle',
   props: {},
   data() {
@@ -37,15 +51,57 @@ export default {
       date: "10.10.2020",
       title : "This is the title",
       author: "enozcan",
-      body : "This is the body text, i don't know what to write, my hands are writing words, asdasdasdasds, haaaaaaandssssss"
+      body : "This is the body text, i don't know what to write, my hands are writing words, asdasdasdasds, haaaaaaandssssss",
+      articleImageUrl : "https://i.sozcu.com.tr/wp-content/uploads/2019/12/09/iecrop/sis-bursa-sis-iha1_10228788_16_9_1575927508-880x495.jpg"
     }
   },
-  created() {},
-  mounted() {},
+  created() {
+    // Text annotation mock
+    var anotator_app = new annotator.App();
+    anotator_app.include(annotator.ui.main);
+    anotator_app
+    .start()
+    .then(function () {
+        anotator_app.annotations.load();
+    });
+  },
+  mounted() {
+    anno.makeAnnotatable(document.getElementById('articleImage'));
+    this.createMockAnnotation()
+  },
   methods: {
     redirectToUser() {
       this.$router.push({ path: `/user/${this.author}/profile` })
-    }
+    },
+    // Create a temp annotation
+    createMockAnnotation() {
+      var myAnnotation = {
+          /** The URL of the image where the annotation should go **/
+          src : this.articleImageUrl,
+
+          /** The annotation text **/
+          text : 'My annotation',
+
+          /** The annotation shape **/
+          shapes : [{
+              /** The shape type **/
+              type : 'rect',
+              /** The shape geometry (relative coordinates) **/
+              geometry : {
+                height: 0.30707070707070705,
+                width: 0.1318181818181818,
+                x: 0.48863636363636365,
+                y: 0.044444444444444446,
+              }
+          }]
+      }
+
+      anno.addAnnotation(myAnnotation)
+
+    },
+
+
+
   }
 }
 </script>
@@ -62,6 +118,10 @@ export default {
   float: left;
   margin-right: 10px;
   border-radius: 50%;
+}
+
+#annotatable {
+  
 }
 
 

--- a/frontend/TraderX/src/views/view-article/index.vue
+++ b/frontend/TraderX/src/views/view-article/index.vue
@@ -66,7 +66,13 @@ export default {
     // this.addAnnotationToImage()
     var that = this
     anno.addHandler('onAnnotationCreated', function(annotation){
-      that.createAnnotation(annotation)
+      that.createAnnotationHandler(annotation)
+    })
+    anno.addHandler('onAnnotationUpdated', function(annotation) {
+      that.updateAnnotationHandler(annotation)
+    })
+    anno.addHandler('onAnnotationRemoved', function(annotation) {
+      that.deleteAnnotationHandler(annotation)
     })
     this.getAnnotationList()
   },
@@ -74,7 +80,6 @@ export default {
     redirectToUser() {
       this.$router.push({ path: `/user/${this.author}/profile` })
     },
-    // Create a temp annotation
     addAnnotationToImage(backendAnnotation) {
       var newAnnotation = {
         src : this.articleImageUrl,
@@ -82,7 +87,8 @@ export default {
         shapes : [{
           type : 'rect',
           geometry : this.renderGeometry(backendAnnotation.target.id)
-        }]
+        }],
+        id : backendAnnotation.id
       }
       anno.addAnnotation(newAnnotation)
     },
@@ -99,9 +105,7 @@ export default {
       }
     },
 
-    createAnnotation(annotation) {
-      // console.log(annotation)
-
+    createAnnotationHandler(annotation) {
       var newAnnotation = {
         "articleId" : parseInt(this.$route.params.articleid),
         "content" : annotation.text,
@@ -112,10 +116,34 @@ export default {
         "imgW": this.imageWidth * annotation.shapes[0].geometry.width,
         "imgH": this.imageHeight * annotation.shapes[0].geometry.height
       }
-      console.log(newAnnotation)
-
-      // Connect this to the backend
       createAnnotation(newAnnotation).then(response => {
+          console.log(response)
+      }).catch(error => {
+          console.log(error)
+      })
+    },
+
+    updateAnnotationHandler(annotation) {
+      var updatedAnnotation = {
+        "articleId" : parseInt(this.$route.params.articleid),
+        "content" : annotation.text,
+        "id" : annotation.id,
+        "bodyType": "Text",
+        "targetType": "Image",
+        "imgX": this.imageWidth * annotation.shapes[0].geometry.x,
+        "imgY": this.imageHeight * annotation.shapes[0].geometry.y,
+        "imgW": this.imageWidth * annotation.shapes[0].geometry.width,
+        "imgH": this.imageHeight * annotation.shapes[0].geometry.height
+      }
+      updateAnnotation(updatedAnnotation).then(response => {
+          console.log(response)
+      }).catch(error => {
+          console.log(error)
+      })
+    },
+
+    deleteAnnotationHandler(annotation) {
+      deleteAnnotation({ "id" : annotation.id }).then(response => {
           console.log(response)
       }).catch(error => {
           console.log(error)
@@ -152,10 +180,5 @@ export default {
   margin-right: 10px;
   border-radius: 50%;
 }
-
-#annotatable {
-  
-}
-
 
 </style>

--- a/frontend/TraderX/src/views/view-article/index.vue
+++ b/frontend/TraderX/src/views/view-article/index.vue
@@ -47,16 +47,7 @@ export default {
       imageHeight: ""
     }
   },
-  created() {
-    // Text annotation mock
-    // var anotator_app = new annotator.App();
-    // anotator_app.include(annotator.ui.main);
-    // anotator_app
-    // .start()
-    // .then(function () {
-    //     anotator_app.annotations.load();
-    // });
-  },
+  created() {},
   mounted() {
     var articleImage = document.getElementById('articleImage'); 
     this.imageWidth = articleImage.clientWidth;


### PR DESCRIPTION
Hello dear frontend fellows, 

Regarding the issue #300 I have added the image annotations to view-article page. 
Users are now able to create, update, delete annotations to the image on the article. 
All of the functions are connected to the backend and they work synchronously.
Following is a GIF that shows the changes: 

![cmpe352_image_annotation](https://user-images.githubusercontent.com/32496519/71324429-a0190780-24ef-11ea-8626-82ebeba75f5a.gif)

It would be great if you could take a look at it!
Thanks!