### PR TITLE
[Frontend] Removed Article List from Detailed Equipment Page

### DIFF
--- a/frontend/TraderX/src/views/trading-equipment/cryptocurrencies.vue
+++ b/frontend/TraderX/src/views/trading-equipment/cryptocurrencies.vue
@@ -96,54 +96,6 @@
                 </el-card>
 
                 <el-card class='container-in-tab'>
-                  <h4> Most reviewed articles about {{ed.label}} </h4>
-
-                  <!-- Got this from complex-table component -->
-                  <el-table
-                    :data="articleList"
-                    border
-                    fit
-                    highlight-current-row
-                    style="width: 100%;"
-                  >
-                    <el-table-column label="ID" prop="id" align="center">
-                      <template slot-scope="scope">
-                        <span>{{ scope.row.id }}</span>
-                      </template>
-                    </el-table-column>
-                    <el-table-column label="Date" align="center">
-                      <template slot-scope="scope">
-                        <span>{{ scope.row.timestamp | parseTime('{y}-{m}-{d} {h}:{i}') }}</span>
-                      </template>
-                    </el-table-column>
-                    <!-- TODO: when pressed to one of the titles it should direct the user to the corresponding article -->
-                    <el-table-column label="Title" >
-                      <template slot-scope="{row}">
-                        <span class="link-type">{{ row.title }}</span>
-                        <!-- <el-tag>{{ row.type | typeFilter }}</el-tag> -->
-                      </template>
-                    </el-table-column>
-                    <el-table-column label="Author" align="center">
-                      <template slot-scope="scope">
-                        <span>{{ scope.row.author }}</span>
-                      </template>
-                    </el-table-column>
-                    <el-table-column label="Importance" >
-                      <template slot-scope="scope">
-                        <svg-icon v-for="n in +scope.row.importance" :key="n" icon-class="star" class="meta-item__icon" />
-                      </template>
-                    </el-table-column>
-                    <el-table-column label="Readings" align="center">
-                      <template slot-scope="{row}">
-                        <span v-if="row.pageviews" class="link-type">{{ row.pageviews }}</span>
-                        <span v-else>0</span>
-                      </template>
-                    </el-table-column>
-                  </el-table>
-                  <el-button class='read-article' style="margin-top:20px;" @click="readArticle(ed.label)"><svg-icon style="margin-right:10px" icon-class="shopping" /> Read More Articles about {{ ed.label }} </el-button>
-                </el-card>
-
-                <el-card class='container-in-tab'>
                   <h4> Comments about {{ ed.label }} </h4>
                   <el-button class='create-comment' style="margin-top:20px;margin-bottom:20px;" @click="showCreateCommentDialog=true">
                     <svg-icon style="margin-right:10px" icon-class="edit" /> Write Comment </el-button>
@@ -290,11 +242,9 @@ export default {
       currentIndex: 0,
       buyamountinput: '',
       select: '',
-      articleList: null
     }
   },
   async created() {
-    this.returnArticleList()
     var equipmentList = await this.getEquipmentList()
     this.getCommentList(equipmentList)
     // Fill the equipmentData with equipment list
@@ -310,57 +260,6 @@ export default {
     this.alertForm.code = this.activeTab
   },
   methods: {
-    // For now it returns mock data
-    // TODO: change this method to get actual articles
-    returnArticleList() {
-      this.articleList = [
-        {
-          id: 1,
-          timestamp: 1024316325463,
-          title: 'Trolollolo',
-          author: 'Irmos',
-          importance: 3,
-          pageviews: 245
-        },
-
-        {
-          id: 2,
-          timestamp: 1012345625463,
-          title: 'Random articlezz',
-          author: 'Sado',
-          importance: 2,
-          pageviews: 12420425
-        },
-
-        {
-          id: 3,
-          timestamp: 1024316325463,
-          title: 'adfniun biyg oiniug',
-          author: 'Yukseljim',
-          importance: 3,
-          pageviews: 15
-        },
-
-        {
-          id: 4,
-          timestamp: 1024313478569,
-          title: 'U picku materinu',
-          author: 'More Irmos',
-          importance: 1,
-          pageviews: 945231
-        },
-
-        {
-          id: 5,
-          timestamp: 1024313456789,
-          title: 'My hands are typing words',
-          author: 'Irmos',
-          importance: 2,
-          pageviews: 8245
-        }
-      ]
-    },
-
         // Comment List will be received for all of the equipment
     async getCommentList(equipmentList) {
       var commentList = {}

--- a/frontend/TraderX/src/views/trading-equipment/money_currencies.vue
+++ b/frontend/TraderX/src/views/trading-equipment/money_currencies.vue
@@ -95,55 +95,6 @@
                 </el-card>
 
                 <el-card class='container-in-tab'>
-                  <h4> Most reviewed articles about {{ed.label}} </h4>
-
-                  <!-- Got this from complex-table component -->
-                  <el-table
-                    :data="articleList"
-                    border
-                    fit
-                    highlight-current-row
-                    style="width: 100%;"
-                  >
-                    <el-table-column label="ID" prop="id" align="center">
-                      <template slot-scope="scope">
-                        <span>{{ scope.row.id }}</span>
-                      </template>
-                    </el-table-column>
-                    <el-table-column label="Date" align="center">
-                      <template slot-scope="scope">
-                        <span>{{ scope.row.timestamp | parseTime('{y}-{m}-{d} {h}:{i}') }}</span>
-                      </template>
-                    </el-table-column>
-                    <!-- TODO: when pressed to one of the titles it should direct the user to the corresponding article -->
-                    <el-table-column label="Title" >
-                      <template slot-scope="{row}">
-                        <span class="link-type">{{ row.title }}</span>
-                        <!-- <el-tag>{{ row.type | typeFilter }}</el-tag> -->
-                      </template>
-                    </el-table-column>
-                    <el-table-column label="Author" align="center">
-                      <template slot-scope="scope">
-                        <span>{{ scope.row.author }}</span>
-                      </template>
-                    </el-table-column>
-                    <el-table-column label="Importance" >
-                      <template slot-scope="scope">
-                        <svg-icon v-for="n in +scope.row.importance" :key="n" icon-class="star" class="meta-item__icon" />
-                      </template>
-                    </el-table-column>
-                    <el-table-column label="Readings" align="center">
-                      <template slot-scope="{row}">
-                        <span v-if="row.pageviews" class="link-type">{{ row.pageviews }}</span>
-                        <span v-else>0</span>
-                      </template>
-                    </el-table-column>
-                  </el-table>
-
-                  <el-button class='read-article' style="margin-top:20px;" @click="readArticle(ed.label)"><svg-icon style="margin-right:10px" icon-class="shopping" /> Read More Articles about {{ ed.label }} </el-button>
-                </el-card>
-
-                <el-card class='container-in-tab'>
                   <h4> Comments about {{ ed.label }} </h4>
                   <el-button class='create-comment' style="margin-top:20px;margin-bottom:20px;" @click="showCreateCommentDialog=true">
                     <svg-icon style="margin-right:10px" icon-class="edit" /> Write Comment </el-button>
@@ -276,27 +227,8 @@ export default {
       select: '',
       createCommentContent: '',
       editCommentContent: '',
-      // equipmentData is expected to be:
-      // [
-      //   {
-      //     label: Euro,
-      //     key: EUR,
-      //     data: {
-      //       open: [...],
-      //       close: [...],
-      //       high: [...],
-      //       low: [...],
-      //       current: [...]
-      //     }
-      //   },
-      //   {
-      //     label: Japanese Yen,
-      //     key: JPY
-      //   }, ...
-      // ]
       equipmentData: [],
       activeTab: 'JPY',
-      articleList: null,
       commentList: {},
       postCommentDict: {
         "comment": "",
@@ -307,7 +239,6 @@ export default {
     }
   },
   async created() {
-    this.returnArticleList()
     var equipmentList = await this.getEquipmentList()
     this.getCommentList(equipmentList)
     // Fill the equipmentData with equipment list
@@ -323,58 +254,6 @@ export default {
     this.editAlertForm.code = this.activeTab
   },
   methods: {
-
-    // For now it returns mock data
-    // TODO: change this method to get actual articles
-    returnArticleList() {
-      this.articleList = [
-        {
-          id: 1,
-          timestamp: 1024316325463,
-          title: 'Trolollolo',
-          author: 'Irmos',
-          importance: 3,
-          pageviews: 245
-        },
-
-        {
-          id: 2,
-          timestamp: 1012345625463,
-          title: 'Random articlezz',
-          author: 'Sado',
-          importance: 2,
-          pageviews: 12420425
-        },
-
-        {
-          id: 3,
-          timestamp: 1024316325463,
-          title: 'adfniun biyg oiniug',
-          author: 'Yukseljim',
-          importance: 3,
-          pageviews: 15
-        },
-
-        {
-          id: 4,
-          timestamp: 1024313478569,
-          title: 'U picku materinu',
-          author: 'More Irmos',
-          importance: 1,
-          pageviews: 945231
-        },
-
-        {
-          id: 5,
-          timestamp: 1024313456789,
-          title: 'My hands are typing words',
-          author: 'Irmos',
-          importance: 2,
-          pageviews: 8245
-        }
-      ]
-    },
-
     // Comment List will be received for all of the equipment
     async getCommentList(equipmentList) {
       var commentList = {}

--- a/frontend/TraderX/src/views/trading-equipment/stocks.vue
+++ b/frontend/TraderX/src/views/trading-equipment/stocks.vue
@@ -95,54 +95,6 @@
                 </el-card>
 
                 <el-card class='container-in-tab'>
-                  <h4> Most reviewed articles about {{ed.label}} </h4>
-
-                  <!-- Got this from complex-table component -->
-                  <el-table
-                    :data="articleList"
-                    border
-                    fit
-                    highlight-current-row
-                    style="width: 100%;"
-                  >
-                    <el-table-column label="ID" prop="id" align="center">
-                      <template slot-scope="scope">
-                        <span>{{ scope.row.id }}</span>
-                      </template>
-                    </el-table-column>
-                    <el-table-column label="Date" align="center">
-                      <template slot-scope="scope">
-                        <span>{{ scope.row.timestamp | parseTime('{y}-{m}-{d} {h}:{i}') }}</span>
-                      </template>
-                    </el-table-column>
-                    <!-- TODO: when pressed to one of the titles it should direct the user to the corresponding article -->
-                    <el-table-column label="Title" >
-                      <template slot-scope="{row}">
-                        <span class="link-type">{{ row.title }}</span>
-                        <!-- <el-tag>{{ row.type | typeFilter }}</el-tag> -->
-                      </template>
-                    </el-table-column>
-                    <el-table-column label="Author" align="center">
-                      <template slot-scope="scope">
-                        <span>{{ scope.row.author }}</span>
-                      </template>
-                    </el-table-column>
-                    <el-table-column label="Importance" >
-                      <template slot-scope="scope">
-                        <svg-icon v-for="n in +scope.row.importance" :key="n" icon-class="star" class="meta-item__icon" />
-                      </template>
-                    </el-table-column>
-                    <el-table-column label="Readings" align="center">
-                      <template slot-scope="{row}">
-                        <span v-if="row.pageviews" class="link-type">{{ row.pageviews }}</span>
-                        <span v-else>0</span>
-                      </template>
-                    </el-table-column>
-                  </el-table>
-                  <el-button class='read-article' style="margin-top:20px;" @click="readArticle(ed.label)"><svg-icon style="margin-right:10px" icon-class="shopping" /> Read More Articles about {{ ed.label }} </el-button>
-                </el-card>
-
-                <el-card class='container-in-tab'>
                   <h4> Comments about {{ ed.label }} </h4>
                   <el-button class='create-comment' style="margin-top:20px;margin-bottom:20px;" @click="showCreateCommentDialog=true">
                     <svg-icon style="margin-right:10px" icon-class="edit" /> Write Comment </el-button>
@@ -276,28 +228,9 @@ export default {
       select: '',
       createCommentContent: '',
       editCommentContent: '',
-      // equipmentData is expected to be:
-      // [
-      //   {
-      //     label: Euro,
-      //     key: EUR,
-      //     data: {
-      //       open: [...],
-      //       close: [...],
-      //       high: [...],
-      //       low: [...],
-      //       current: [...]
-      //     }
-      //   },
-      //   {
-      //     label: Japanese Yen,
-      //     key: JPY
-      //   }, ...
-      // ]
       equipmentData: [],
       comparisonData: {equipmentData: []},
       activeTab: 'ORCL',
-      articleList: null,
       commentList: {},
       postCommentDict: {
         "comment": "",
@@ -308,7 +241,6 @@ export default {
     }
   },
   async created() {
-    this.returnArticleList()
     var equipmentList = await this.getEquipmentList()
     this.getCommentList(equipmentList)
     // Fill the equipmentData with equipment list
@@ -324,58 +256,7 @@ export default {
     this.alertForm.code = this.activeTab
   },
   methods: {
-    // For now it returns mock data
-    // TODO: change this method to get actual articles
-    returnArticleList() {
-      this.articleList = [
-        {
-          id: 1,
-          timestamp: 1024316325463,
-          title: 'Trolollolo',
-          author: 'Irmos',
-          importance: 3,
-          pageviews: 245
-        },
-
-        {
-          id: 2,
-          timestamp: 1012345625463,
-          title: 'Random articlezz',
-          author: 'Sado',
-          importance: 2,
-          pageviews: 12420425
-        },
-
-        {
-          id: 3,
-          timestamp: 1024316325463,
-          title: 'adfniun biyg oiniug',
-          author: 'Yukseljim',
-          importance: 3,
-          pageviews: 15
-        },
-
-        {
-          id: 4,
-          timestamp: 1024313478569,
-          title: 'U picku materinu',
-          author: 'More Irmos',
-          importance: 1,
-          pageviews: 945231
-        },
-
-        {
-          id: 5,
-          timestamp: 1024313456789,
-          title: 'My hands are typing words',
-          author: 'Irmos',
-          importance: 2,
-          pageviews: 8245
-        }
-      ]
-    },
-
-        // Comment List will be received for all of the equipment
+    // Comment List will be received for all of the equipment
     async getCommentList(equipmentList) {
       var commentList = {}
       equipmentList.forEach(async function(e) {


### PR DESCRIPTION
According to our last discussion, and regarding the issue #250  we decided to remove the article list from the detailed page considering the fact that it requires active use of tags which is not that case for our system currently. 
Article List in detailed page however can be future feature. 
But for now, this PR deletes the list. 
It would be great if you could take a look at it.
Thanks!