### PR TITLE
[Frontend] Fixed Static Article Info Problem

### DIFF
--- a/frontend/TraderX/src/views/view-article/index.vue
+++ b/frontend/TraderX/src/views/view-article/index.vue
@@ -86,7 +86,7 @@ export default {
       title : "",
       author: "",
       body : "",
-      articleImageUrl : "https://www.fx-exchange.com/currencyimages/usd-jpy-90-day-exchange-rates-history-graph.png",
+      articleImageUrl: "",
       imageWidth: "",
       imageHeight: "",
       articleCommentList: [],
@@ -107,38 +107,53 @@ export default {
     this.getArticleInfo()
   },
   mounted() {
-    var articleImage = document.getElementById('articleImage'); 
-    this.imageWidth = articleImage.clientWidth;
-    this.imageHeight = articleImage.clientHeight;
-
-    anno.makeAnnotatable(articleImage);
-    var that = this
-    anno.addHandler('onAnnotationCreated', function(annotation){
-      that.createAnnotationHandler(annotation)
-    })
-    anno.addHandler('onAnnotationUpdated', function(annotation) {
-      that.updateAnnotationHandler(annotation)
-    })
-    anno.addHandler('onAnnotationRemoved', function(annotation) {
-      that.deleteAnnotationHandler(annotation)
-    })
-    this.getAnnotationList()
+    this.waitForImageUrl()
   },
   methods: {
+    waitForImageUrl() {
+      if(this.articleImageUrl !== ""){
+        console.log('imageUrl in wait: ' + this.articleImageUrl)
+        this.setupAnnotation()
+      }
+      else{
+        console.log('imageUrl is undefined: ' + this.articleImageUrl)
+        setTimeout(this.waitForImageUrl, 250);
+      }
+    },
+
+    setupAnnotation() {
+      console.log('this.articleImageUrl: ' + this.articleImageUrl)
+      var articleImage = document.getElementById('articleImage'); 
+      this.imageWidth = articleImage.clientWidth;
+      this.imageHeight = articleImage.clientHeight;
+
+      anno.makeAnnotatable(articleImage);
+      var that = this
+      anno.addHandler('onAnnotationCreated', function(annotation){
+        that.createAnnotationHandler(annotation)
+      })
+      anno.addHandler('onAnnotationUpdated', function(annotation) {
+        that.updateAnnotationHandler(annotation)
+      })
+      anno.addHandler('onAnnotationRemoved', function(annotation) {
+        that.deleteAnnotationHandler(annotation)
+      })
+      this.getAnnotationList()
+    },
+
     getArticleInfo(){
       var id = this.$route.path.split('/')[2]
       this.$store.dispatch('search/getArticleByID', id ).then(() => {
-        console.log("innn")
-        console.log(this.$store.getters.oneArticle)
         this.date = this.$store.getters.oneArticle.createdAt
         this.author = this.$store.getters.oneArticle.username
         this.title = this.$store.getters.oneArticle.header
         this.body = this.$store.getters.oneArticle.body
-        // this.articleImageUrl = this.$store.getters.oneArticle.imageUrl
+        this.articleImageUrl = this.$store.getters.oneArticle.imageUrl
       }).catch(err => {
         console.log(err)
       })
     },
+
     redirectToUser() {
       this.$router.push({ path: `/user/${this.author}/profile` })
     },


### PR DESCRIPTION
Hey guys, 

As was discussed before, we had a minor problem with image annotation and viewing articles in general. When we wanted to see an article, although the website receives the article information it receives it after it renders the page thus causing the article to not show up properly. 
The same behaviour of the articles also caused image annotation to load before the image info has arrived which sometimes breaks image annotation.

This pull requests fixes this problem by waiting for the information before setting up the image annotation.
Followings are screenshots of image annotation. 

![imageannotation_show](https://user-images.githubusercontent.com/32496519/71646085-1fc68380-2cf3-11ea-9960-e9e7626bd220.png)
![imageannotation_write](https://user-images.githubusercontent.com/32496519/71646086-205f1a00-2cf3-11ea-8d16-3c63dd846d3c.png)
 
I do have one minor problem with this issue though and that is the article page needs a refresh to load properly. I couldn't solve this problem unfortunately.

It would be great if you could take a look at the changes. 
Thanks in advance!